### PR TITLE
bugfix for CompoundSerializer.unpack_read

### DIFF
--- a/structured/base_types.py
+++ b/structured/base_types.py
@@ -244,11 +244,13 @@ class CompoundSerializer(Serializer):
         return tuple(chain(*values))
 
     def unpack_read(self, readable: SupportsRead) -> tuple:
-        return tuple(chain(
-            *(serializer.unpack_read(readable)
-              for serializer in self.serializers
-             )
-        ))
+        values = []
+        size = 0
+        for serializer in self.serializers:
+            values.append(serializer.unpack_read(readable))
+            size += serializer.size
+        self.size = size
+        return tuple(chain(*values))
 
 
 @cache

--- a/tests/test_arrays.py
+++ b/tests/test_arrays.py
@@ -277,12 +277,13 @@ def test_dynamic_structured():
 
 def test_dynamic_checked_structured():
     class Compound(Structured):
+        b: uint32
         a: array[Header[uint32, uint32], Item]
-    target_obj = Compound([Item(1, 11), Item(2, 22), Item(3, 33)])
+    target_obj = Compound(42, [Item(1, 11), Item(2, 22), Item(3, 33)])
 
     with io.BytesIO() as out:
         array_size = Item.serializer.size * 3
-        out.write(struct.pack('2I', 3, array_size))
+        out.write(struct.pack('3I', 42, 3, array_size))
         for item in target_obj.a:
             item.pack_write(out)
         target_data = out.getvalue()
@@ -308,7 +309,7 @@ def test_dynamic_checked_structured():
         assert Compound.create_unpack_read(stream) == target_obj
 
     # Test malformed data_size
-    st = struct.Struct(uint32.format)
-    st.pack_into(buffer, 0, 0)      # write over data_size with 0
+    st = struct.Struct('3I')
+    st.pack_into(buffer, 0, 42, 3, 0)      # write over data_size with 0
     with pytest.raises(ValueError):
         Compound.create_unpack_from(buffer)


### PR DESCRIPTION
Current implementation wasn't updating self.size
Modified the array[Header[uint*, uint*], *] test to a form that catches the case that triggered the bug.