### PR TITLE
Generic structured

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,3 +288,17 @@ class MyGeneric(Generic[T, U], Structured):
 
 class ConcreteClass(MyGeneric[uint8, uint32]): pass
 ```
+
+One **limitation** here however, you cannot use a generic Structured class as an array object type.  It will act as the base class without specialization (See #8).  So for example, the following code will not work as you expect:
+```python
+class Item(Generic[T], Structured):
+  a: T
+
+class MyStruct(Generic[T], Structured):
+  items: array[Header[10], Item[T]]
+
+class Concrete(MyStruct[uint32]): pass
+
+assert Concrete.args == ('items', )
+> AssertionError
+```

--- a/README.md
+++ b/README.md
@@ -275,3 +275,16 @@ class MyStruct(Structured):
 ```
 
 No solution is perfect, and any type checker set to a strict level will complain about a lot of code.
+
+
+## Generic `Structured` classes
+You can also create your `Structured` class as a `Generic`.  Due to details of how `typing.Generic` works, to get a working specialized version, you must subclass the specialization:
+
+```python
+class MyGeneric(Generic[T, U], Structured):
+  a: T
+  b: array[Header[10], U]
+
+
+class ConcreteClass(MyGeneric[uint8, uint32]): pass
+```

--- a/README.md
+++ b/README.md
@@ -283,7 +283,7 @@ You can also create your `Structured` class as a `Generic`.  Due to details of h
 ```python
 class MyGeneric(Generic[T, U], Structured):
   a: T
-  b: array[Header[10], U]
+  b: list[U] = serializerd(array[Header[10], U])
 
 
 class ConcreteClass(MyGeneric[uint8, uint32]): pass

--- a/structured/complex_types/array_headers.py
+++ b/structured/complex_types/array_headers.py
@@ -6,8 +6,9 @@ values.
 from __future__ import annotations
 
 from functools import cache
+from typing import TypeVar
 
-from ..utils import specialized
+from ..utils import StructuredAlias, specialized
 from ..structured import Structured
 from ..basic_types import uint8, uint16, uint32, uint64
 from ..type_checking import ClassVar, Union
@@ -278,6 +279,9 @@ class Header(Structured, HeaderBase):
             raise TypeError(f'{cls.__name__}[] expected two arguments')
         else:
             count, size_check = key
+        # TypeVar checks:
+        if isinstance(count, TypeVar) or isinstance(size_check, TypeVar):
+            return StructuredAlias(cls, (count, size_check))
         try:
             if size_check is None:
                 args = (count,)

--- a/structured/complex_types/array_headers.py
+++ b/structured/complex_types/array_headers.py
@@ -6,15 +6,17 @@ values.
 from __future__ import annotations
 
 from functools import cache
-from typing import TypeVar
 
 from ..utils import StructuredAlias, specialized
 from ..structured import Structured
 from ..basic_types import uint8, uint16, uint32, uint64
-from ..type_checking import ClassVar, Union
+from ..type_checking import ClassVar, Union, Generic, Optional, TypeVar
 
 
+_SizeTypes = (uint8, uint16, uint32, uint64)
 SizeTypes = Union[uint8, uint16, uint32, uint64]
+TSize = TypeVar('TSize', bound=SizeTypes)
+TCount = TypeVar('TCount', bound=SizeTypes)
 
 
 class HeaderBase:
@@ -54,68 +56,45 @@ class StaticHeader(HeaderBase, Structured):
                 f'expected an array of length {self.count}, but got {new_count}'
             )
 
-    def __class_getitem__(
-            cls: type[StaticHeader],
-            count: int,
-        ) -> type[StaticHeader]:
+    @classmethod
+    def specialize(cls, count: int) -> type[StaticHeader]:
         """Specialize for a specific static size."""
         if count <= 0:
             raise ValueError('count must be positive')
-        class _StaticHeader(cls):
+        class _StaticHeader(StaticHeader):
             _count: ClassVar[int] = count
         return _StaticHeader
 
 
-class DynamicHeader(Structured, HeaderBase):
+class DynamicHeader(Generic[TCount], Structured, HeaderBase):
     """Base for dynamically sized arrays, where the array length is just prior
     to the array data.
     """
-    count: int
+    count: TCount
     data_size: ClassVar[int] = 0
     two_pass: ClassVar[bool] = False
 
-    _headers = {}
-
     def __init__(self, count: int, data_size: int) -> None:
         """Only `count` is packed/unpacked."""
-        self.count = count
+        self.count = count  # type: ignore
 
-    def __class_getitem__(
-            cls,
-            count_type: type[SizeTypes],
-        ) -> type[DynamicHeader]:
-        """Specialize based on the uint* type used to store the array length."""
-        return cls._headers[count_type]
-
-class _DynamicHeader8(DynamicHeader):
-    count: uint8
-class _DynamicHeader16(DynamicHeader):
-    count: uint16
-class _DynamicHeader32(DynamicHeader):
-    count: uint32
-class _DynamicHeader64(DynamicHeader):
-    count: uint64
-DynamicHeader._headers = {
-    uint8: _DynamicHeader8,
-    uint16: _DynamicHeader16,
-    uint32: _DynamicHeader32,
-    uint64: _DynamicHeader64,
-}
+    @classmethod
+    def specialize(cls, count_type: type[SizeTypes]) -> type[DynamicHeader]:
+        class _DynamicHeader(DynamicHeader[count_type]): pass
+        return _DynamicHeader
 
 
-class StaticCheckedHeader(Structured, HeaderBase):
+class StaticCheckedHeader(Generic[TSize], Structured, HeaderBase):
     """Statically sized array, with a size check int packed just prior to the
     array data.
     """
     _count: ClassVar[int] = 0
-    data_size: int
+    data_size: TSize
     two_pass: ClassVar[bool] = True
-
-    _headers = {}
 
     def __init__(self, count: int, data_size: int) -> None:
         """Only `data_size` is packed/unpacked."""
-        self.data_size = data_size
+        self.data_size = data_size  # type: ignore
 
     def validate_data_size(self, data_size: int) -> None:
         """Verify correct amount of bytes were read."""
@@ -139,39 +118,20 @@ class StaticCheckedHeader(Structured, HeaderBase):
                 f'{new_count}'
             )
 
-    def __class_getitem__(
-            cls: type[StaticCheckedHeader],
-            key: tuple[int, type[SizeTypes]],
-        ) -> type[StaticCheckedHeader]:
+    @classmethod
+    def specialize(cls, count: int, size_type: type[SizeTypes]) -> type[StaticCheckedHeader]:
         """Specialize for the specific static size and check type."""
-        count, size_type = key
         if count <= 0:
             raise ValueError('count must be positive')
-        base = cls._headers[size_type]
-        class _StaticCheckedHeader(base):
+        class _StaticCheckedHeader(StaticCheckedHeader[size_type]):
             _count: ClassVar[int] = count
         return _StaticCheckedHeader
 
-class _StaticCheckedHeader8(StaticCheckedHeader):
-    data_size: uint8
-class _StaticCheckedHeader16(StaticCheckedHeader):
-    data_size: uint16
-class _StaticChechedHeader32(StaticCheckedHeader):
-    data_size: uint32
-class _StaticCheckedHeader64(StaticCheckedHeader):
-    data_size: uint64
-StaticCheckedHeader._headers = {
-    uint8: _StaticCheckedHeader8,
-    uint16: _StaticCheckedHeader16,
-    uint32: _StaticChechedHeader32,
-    uint64: _StaticCheckedHeader64,
-}
 
-
-class DynamicCheckedHeader(Structured, HeaderBase):
+class DynamicCheckedHeader(Generic[TCount, TSize], Structured, HeaderBase):
     """Dynamically sized array with a size check."""
-    count: int
-    data_size: int
+    count: TCount
+    data_size: TSize
     two_pass: ClassVar[bool] = True
 
     _headers = {}
@@ -184,79 +144,10 @@ class DynamicCheckedHeader(Structured, HeaderBase):
                 f'got {data_size}'
             )
 
-    def __class_getitem__(
-            cls: type[DynamicCheckedHeader],
-            key: tuple[type[SizeTypes], type[SizeTypes]],
-        ) -> type[DynamicCheckedHeader]:
-        """Specialize based on size type and check type."""
-        return cls._headers[key]
-
-class _DynamicCheckedHeader8_8(DynamicCheckedHeader):
-    count: uint8
-    data_size: uint8
-class _DynamicCheckedHeader8_16(DynamicCheckedHeader):
-    count: uint8
-    data_size: uint16
-class _DynamicCheckedHeader8_32(DynamicCheckedHeader):
-    count: uint8
-    data_size: uint32
-class _DynamicCheckedHeader8_64(DynamicCheckedHeader):
-    count: uint8
-    data_size: uint64
-class _DynamicCheckedHeader16_8(DynamicCheckedHeader):
-    count: uint16
-    data_size: uint8
-class _DynamicCheckedHeader16_16(DynamicCheckedHeader):
-    count: uint16
-    data_size: uint16
-class _DynamicCheckedHeader16_32(DynamicCheckedHeader):
-    count: uint16
-    data_size: uint32
-class _DynamicCheckedHeader16_64(DynamicCheckedHeader):
-    count: uint16
-    data_size: uint64
-class _DynamicCheckedHeader32_8(DynamicCheckedHeader):
-    count: uint32
-    data_size: uint8
-class _DynamicCheckedHeader32_16(DynamicCheckedHeader):
-    count: uint32
-    data_size: uint16
-class _DynamicCheckedHeader32_32(DynamicCheckedHeader):
-    count: uint32
-    data_size: uint32
-class _DynamicCheckedHeader32_64(DynamicCheckedHeader):
-    count: uint32
-    data_size: uint64
-class _DynamicCheckedHeader64_8(DynamicCheckedHeader):
-    count: uint64
-    data_size: uint8
-class _DynamicCheckedHeader64_16(DynamicCheckedHeader):
-    count: uint64
-    data_size: uint16
-class _DynamicCheckedHeader64_32(DynamicCheckedHeader):
-    count: uint64
-    data_size: uint32
-class _DynamicCheckedHeader64_64(DynamicCheckedHeader):
-    count: uint64
-    data_size: uint64
-DynamicCheckedHeader._headers = {
-    (uint8, uint8): _DynamicCheckedHeader8_8,
-    (uint8, uint16): _DynamicCheckedHeader8_16,
-    (uint8, uint32): _DynamicCheckedHeader8_32,
-    (uint8, uint64): _DynamicCheckedHeader8_64,
-    (uint16, uint8): _DynamicCheckedHeader16_8,
-    (uint16, uint16): _DynamicCheckedHeader16_16,
-    (uint16, uint32): _DynamicCheckedHeader16_32,
-    (uint16, uint64): _DynamicCheckedHeader16_64,
-    (uint32, uint8): _DynamicCheckedHeader32_8,
-    (uint32, uint16): _DynamicCheckedHeader32_16,
-    (uint32, uint32): _DynamicCheckedHeader32_32,
-    (uint32, uint64): _DynamicCheckedHeader32_64,
-    (uint64, uint8): _DynamicCheckedHeader64_8,
-    (uint64, uint16): _DynamicCheckedHeader64_16,
-    (uint64, uint32): _DynamicCheckedHeader64_32,
-    (uint64, uint64): _DynamicCheckedHeader64_64,
-}
+    @classmethod
+    def specialize(cls, count_type: type[SizeTypes], size_type: type[SizeTypes]) -> type[DynamicCheckedHeader]:
+        class _DynamicCheckedHeader(DynamicCheckedHeader[count_type, size_type]): pass
+        return _DynamicCheckedHeader
 
 
 class Header(Structured, HeaderBase):
@@ -267,37 +158,42 @@ class Header(Structured, HeaderBase):
     data_size: int
     two_pass: ClassVar[bool]
 
-    @classmethod
-    @cache
     def __class_getitem__(cls, key) -> type[Header]:
         """Main entry point for making Headers.  Do type checks and create the
         appropriate Header type.
         """
         if not isinstance(key, tuple):
-            count, size_check = key, None
-        elif len(key) != 2:
-            raise TypeError(f'{cls.__name__}[] expected two arguments')
-        else:
-            count, size_check = key
-        # TypeVar checks:
+            key = (key, )
+        return cls.create(*key)
+
+    @classmethod
+    def create(cls, count, size_check=None):
+        return cls._create(count, size_check)
+
+    @classmethod
+    @cache
+    def _create(cls, count: Union[int, type[SizeTypes]], size_check: Optional[type[SizeTypes]]) -> type[Header]:
+        # TypeVar quick out.
         if isinstance(count, TypeVar) or isinstance(size_check, TypeVar):
-            return StructuredAlias(cls, (count, size_check))
-        try:
-            if size_check is None:
-                args = (count,)
-                if isinstance(count, int):
-                    header = StaticHeader[count]
-                else:
-                    header = DynamicHeader[count]
+            return StructuredAlias(cls, (count, size_check))    # type: ignore
+        # Final type checking
+        if size_check is not None:
+            if not isinstance(size_check, type) or not issubclass(size_check, _SizeTypes):
+                raise TypeError('size check must be a uint* type.')
+        elif not isinstance(count, int):
+            if not isinstance(count, type) or not issubclass(count, _SizeTypes):
+                raise TypeError('array length must be an integer or uint* type.')
+        # Dispatch
+        if size_check is None:
+            args = (count, )
+            if isinstance(count, int):
+                header = StaticHeader.specialize(count)
             else:
-                args = (count, size_check)
-                if isinstance(count, int):
-                    header = StaticCheckedHeader[count, size_check]
-                else:
-                    header = DynamicCheckedHeader[count, size_check]
-            return specialized(cls, *args)(header)  # type: ignore
-        except KeyError:
-            raise TypeError(
-                f'{cls.__name__}[] expected first argument integer or uint* '
-                'type, second argument uint* type or None'
-            ) from None
+                header = DynamicHeader.specialize(count)
+        else:
+            args = (count, size_check)
+            if isinstance(count, int):
+                header = StaticCheckedHeader.specialize(count, size_check)
+            else:
+                header = DynamicCheckedHeader.specialize(count, size_check)
+        return specialized(cls, *args)(header)  # type: ignore

--- a/structured/complex_types/arrays.py
+++ b/structured/complex_types/arrays.py
@@ -75,8 +75,10 @@ class array(list[U], requires_indexing, Generic[T, U]):
             header = Header[args[:-1]]
             array_type = args[-1]
         # TypeVar checks:
-        if isinstance(header, StructuredAlias) or isinstance(array_type, TypeVar):
-            return StructuredAlias(cls, (header, array_type))
+        if (isinstance(header, StructuredAlias) or
+            isinstance(array_type, TypeVar)):
+            return StructuredAlias(cls, (header, array_type))   # type: ignore
+        # Type checking
         if (not isinstance(header, type) or
             not issubclass(header, HeaderBase) or
             header is HeaderBase or

--- a/structured/complex_types/arrays.py
+++ b/structured/complex_types/arrays.py
@@ -74,6 +74,9 @@ class array(list[U], requires_indexing, Generic[T, U]):
         else:
             header = Header[args[:-1]]
             array_type = args[-1]
+        # TypeVar checks:
+        if isinstance(header, StructuredAlias) or isinstance(array_type, TypeVar):
+            return StructuredAlias(cls, (header, array_type))
         if (not isinstance(header, type) or
             not issubclass(header, HeaderBase) or
             header is HeaderBase or

--- a/structured/complex_types/strings.py
+++ b/structured/complex_types/strings.py
@@ -72,7 +72,7 @@ class char(_char):
         elif count is NET:
             new_cls = _net_char
         elif isinstance(count, TypeVar):
-            return StructuredAlias(cls, (count,))
+            return StructuredAlias(cls, (count,))   # type: ignore
         else:
             raise TypeError(
                 f'{cls.__qualname__}[] count must be an int, NET, or uint* '
@@ -154,11 +154,12 @@ class unicode(str, requires_indexing):
         :return: The specialized class.
         """
         if isinstance(count, TypeVar):
-            return StructuredAlias(cls, (count, encoding))
+            return StructuredAlias(cls, (count, encoding))  # type: ignore
         if isinstance(encoding, str):
             encoder = partial(str.encode, encoding=encoding)
             decoder = partial(bytes.decode, encoding=encoding)
-        elif isinstance(encoding, type) and issubclass(encoding, EncoderDecoder):
+        elif (isinstance(encoding, type) and
+              issubclass(encoding, EncoderDecoder)):
             encoder = encoding.encode
             decoder = encoding.decode
         else:
@@ -421,7 +422,12 @@ def unicode_wrap(
         def pack(self, *values: Any) -> bytes:
             return super().pack(self.encoder(values[0]))
 
-        def pack_into(self, buffer: WritableBuffer, offset: int, *values: str) -> None:
+        def pack_into(
+                self,
+                buffer: WritableBuffer,
+                offset: int,
+                *values: str,
+            ) -> None:
             super().pack_into(buffer, offset, self.encoder(values[0]))
 
         def pack_write(self, writable: SupportsWrite, *values: str) -> None:
@@ -430,7 +436,11 @@ def unicode_wrap(
         def unpack(self, buffer: ReadableBuffer) -> tuple[str]:
             return self.decoder(super().unpack(buffer)[0]).rstrip('\0'),
 
-        def unpack_from(self, buffer: ReadableBuffer, offset: int = 0) -> tuple[str]:
+        def unpack_from(
+                self,
+                buffer: ReadableBuffer,
+                offset: int = 0,
+            ) -> tuple[str]:
             return self.decoder(
                 super().unpack_from(buffer, offset)[0]).rstrip('\0'),
 

--- a/structured/complex_types/strings.py
+++ b/structured/complex_types/strings.py
@@ -10,8 +10,9 @@ __all__ = [
 
 from functools import cache, partial
 import struct
+from typing import TypeVar
 
-from ..utils import specialized
+from ..utils import StructuredAlias, specialized
 from ..base_types import (
     Serializer, StructSerializer, requires_indexing, ByteOrder, struct_cache,
     structured_type, counted,
@@ -59,6 +60,7 @@ class char(_char):
         return cls._create(*args)
 
     @classmethod
+    @cache
     def _create(
             cls,
             count: Union[int, type[SizeTypes], type[NET]],
@@ -69,6 +71,8 @@ class char(_char):
             new_cls = _dynamic_char[count]
         elif count is NET:
             new_cls = _net_char
+        elif isinstance(count, TypeVar):
+            return StructuredAlias(cls, (count,))
         else:
             raise TypeError(
                 f'{cls.__qualname__}[] count must be an int, NET, or uint* '
@@ -117,11 +121,15 @@ class unicode(str, requires_indexing):
     :type encoding: Union[str, type[EncoderDecoder]]
     """
     @classmethod
-    @cache
     def __class_getitem__(cls, args) -> type[Serializer]:
         """Create the specialization."""
         if not isinstance(args, tuple):
             args = (args, )
+        # Cache doesn't place nice with default args,
+        # _create(uint8)
+        # _create(uint8, 'utf8')
+        # technically are different call types, so the cache isn't hit.
+        # Pass through an intermediary to take care of this.
         return cls.create(*args)
 
     @classmethod
@@ -130,12 +138,23 @@ class unicode(str, requires_indexing):
             count: Union[int, type[SizeTypes], type[NET]],
             encoding: Union[str, type[EncoderDecoder]] = 'utf8',
         ) -> type[Serializer]:
+        return cls._create(count, encoding)
+
+    @classmethod
+    @cache
+    def _create(
+            cls,
+            count: Union[int, type[SizeTypes], type[NET]],
+            encoding: Union[str, type[EncoderDecoder]],
+        ) -> type[Serializer]:
         """Create the specialization.
 
         :param count: Size of the *encoded* string.
         :param encoding: Encoding method to use.
         :return: The specialized class.
         """
+        if isinstance(count, TypeVar):
+            return StructuredAlias(cls, (count, encoding))
         if isinstance(encoding, str):
             encoder = partial(str.encode, encoding=encoding)
             decoder = partial(bytes.decode, encoding=encoding)

--- a/structured/structured.py
+++ b/structured/structured.py
@@ -34,7 +34,9 @@ def validate_typehint(attr_type: type) -> TypeGuard[type[_Annotation]]:
             if issubclass(attr_type, (format_type, Serializer)):
                 return True
             else:
-                raise TypeError(f'Unknown structured type {attr_type.__qualname__}')
+                raise TypeError(
+                    f'Unknown structured type {attr_type.__qualname__}'
+                )
     return False
 
 
@@ -48,7 +50,10 @@ def serialized(kind: type[structured_type]) -> Any:
     return kind
 
 
-def filter_typehints(typehints: dict[str, Any], classdict: dict[str, Any]) -> dict[str, type[_Annotation]]:
+def filter_typehints(
+        typehints: dict[str, Any],
+        classdict: dict[str, Any],
+    ) -> dict[str, type[_Annotation]]:
     filtered = {
         attr: attr_type
         for attr, attr_type in typehints.items()
@@ -348,7 +353,8 @@ class Structured:
             base_to_origbase = {
                 origin: orig_base
                 for orig_base in orig_bases
-                if (origin := get_origin(orig_base)) and issubclass(origin, Structured)
+                if (origin := get_origin(orig_base))
+                    and issubclass(origin, Structured)
             }
             orig_base = base_to_origbase.get(base, None)
             if orig_base:

--- a/structured/structured.py
+++ b/structured/structured.py
@@ -3,6 +3,8 @@ import operator
 from typing import get_args, get_origin
 import typing
 
+from structured.utils import StructuredAlias
+
 __all__ = [
     'Structured',
     'ByteOrder', 'ByteOrderMode',
@@ -380,6 +382,8 @@ class Structured:
                 # Attribute's final type hint comes from this class
                 if remapped_type := tvar_map.get(attr_type, None):
                     annotations[attr] = remapped_type
+                elif isinstance(attr_type, StructuredAlias):
+                    annotations[attr] = attr_type.resolve(tvar_map)
         all_annotations = [annotations]
         for base, alias in supers.items():
             args = get_args(alias)

--- a/structured/type_checking.py
+++ b/structured/type_checking.py
@@ -14,6 +14,25 @@ else:
 _T = TypeVar('_T')
 
 
+def update_annotations(cls: type, annotations: dict[str, Any]) -> None:
+    """Python <3.10 compatible way to update a class's annotations dict. See:
+
+    https://docs.python.org/3/howto/annotations.html#accessing-the-annotations-dict-of-an-object-in-python-3-9-and-older
+    """
+    if '__annotations__' in cls.__dict__:
+        cls.__annotations__.update(annotations)
+    else:
+        setattr(cls, '__annotations__', annotations)
+
+def get_annotations(cls: type) -> dict[str, Any]:
+    """Python <3.10 compatible way to get a class's annotations dict.  See:
+
+    https://docs.python.org/3/howto/annotations.html#accessing-the-annotations-dict-of-an-object-in-python-3-9-and-older
+    """
+    return cls.__dict__.get('__annotations__', {})
+
+
+
 def isclassvar(annotation: Any) -> bool:
     """Determine if a type annotations is for a class variable.
 

--- a/structured/utils.py
+++ b/structured/utils.py
@@ -35,6 +35,9 @@ def specialized(base_cls: type, *args: Any) -> Callable[[type[_T]], type[_T]]:
 
 
 class StructuredAlias:
+    """Class to hold one of the structured types that takes types as arguments,
+    which has been passes either another StructuredAlias or a TypeVar.
+    """
     cls: type
     args: tuple
 
@@ -50,9 +53,12 @@ class StructuredAlias:
                 arg = arg.resolve(tvar_map)
             resolved.append(arg)
         resolved = tuple(resolved)
-        if any((isinstance(arg, (TypeVar, StructuredAlias)) for arg in resolved)):
+        if any((
+                isinstance(arg, (TypeVar, StructuredAlias))
+                for arg in resolved
+            )):
             # Act as immutable, so create a new instance, since these objects
             # are often cached in type factory indexing methods.
             return StructuredAlias(self.cls, resolved)
         else:
-            return self.cls[resolved]
+            return self.cls[resolved]   # type: ignore

--- a/structured/utils.py
+++ b/structured/utils.py
@@ -1,6 +1,7 @@
 """
 Various utility methods.
 """
+from typing import TypeVar
 from .type_checking import _T, NoReturn, Any, Callable
 
 
@@ -31,3 +32,27 @@ def specialized(base_cls: type, *args: Any) -> Callable[[type[_T]], type[_T]]:
         cls.__name__ = f'{base_cls.__name__}[{name}]'
         return cls
     return wrapper
+
+
+class StructuredAlias:
+    cls: type
+    args: tuple
+
+    def __init__(self, cls, args):
+        self.cls = cls
+        self.args = args
+
+    def resolve(self, tvar_map: dict[TypeVar, type]):
+        resolved = []
+        for arg in self.args:
+            arg = tvar_map.get(arg, arg)
+            if isinstance(arg, StructuredAlias):
+                arg = arg.resolve(tvar_map)
+            resolved.append(arg)
+        resolved = tuple(resolved)
+        if any((isinstance(arg, (TypeVar, StructuredAlias)) for arg in resolved)):
+            # Act as immutable, so create a new instance, since these objects
+            # are often cached in type factory indexing methods.
+            return StructuredAlias(self.cls, resolved)
+        else:
+            return self.cls[resolved]

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -128,4 +128,4 @@ def test_errors() -> None:
         a: uint8
 
     with pytest.raises(TypeError):
-        NotGeneric._specialize(uint8)
+        NotGeneric._get_specialization_hints(uint8)

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -1,9 +1,15 @@
 import struct
 from structured import *
-from typing import Generic, TypeVar, Union
+from typing import Generic, TypeVar, Union, get_type_hints
+
+from structured.utils import StructuredAlias
 
 _Byte = TypeVar('_Byte', bound=Union[uint8, int8])
 _String = TypeVar('_String', bound=Union[char, pascal, unicode])
+_Size = TypeVar('_Size', bound=Union[uint8, uint16, uint32, uint64])
+T = TypeVar('T', bound=Structured)
+U = TypeVar('U')
+V = TypeVar('V')
 
 
 class Base(Generic[_Byte, _String], Structured):
@@ -15,9 +21,86 @@ class UnsignedUnicode(Base[uint8, unicode[uint8]]):
     pass
 
 
-def test_generics() -> None:
-    obj = UnsignedUnicode(10, 'Hello')
-    target_data = struct.pack('BB5s', 10, 5, b'Hello')
+class TestAliasing:
+    class Item(Structured):
+        a: int8
 
-    # pack/unpack
-    assert obj.pack() == target_data
+    tvar_map = {
+        _Size: uint32,
+        _Byte: uint8,
+        T: Item,
+    }
+
+    def test_unicode(self) -> None:
+        obj = unicode[_Size]
+        assert isinstance(obj, StructuredAlias)
+        assert obj.cls is unicode
+        assert obj.args == (_Size, 'utf8')
+        assert obj.resolve(self.tvar_map) is unicode[uint32]
+
+    def test_Header(self) -> None:
+        obj = Header[1, _Size]
+        assert isinstance(obj, StructuredAlias)
+        assert obj.cls is Header
+        assert obj.args == (1, _Size)
+        assert obj.resolve(self.tvar_map) is Header[1, uint32]
+
+    def test_char(self) -> None:
+        obj = char[_Size]
+        assert isinstance(obj, StructuredAlias)
+        assert obj.cls is char
+        assert obj.args == (_Size,)
+        assert obj.resolve(self.tvar_map) is char[uint32]
+
+    def test_array(self) -> None:
+        # same typevar
+        obj = array[Header[_Size], _Size]
+        assert isinstance(obj, StructuredAlias)
+        assert obj.cls is array
+        assert obj.args == (Header[_Size], _Size)
+        assert obj.resolve(self.tvar_map) is array[Header[uint32], uint32]
+
+        # different typevars
+        obj = array[Header[_Size, _Byte], T]
+        assert isinstance(obj, StructuredAlias)
+        assert obj.cls is array
+        assert obj.args == (Header[_Size, _Byte], T)
+
+        obj1 = obj.resolve({_Size: uint32})
+        assert isinstance(obj1, StructuredAlias)
+        assert isinstance(obj1.args[0], StructuredAlias)
+        assert obj1.args[0].args == (uint32, _Byte)
+        assert obj1.args[1] is T
+
+        obj2 = obj1.resolve({_Byte: uint8})
+        assert isinstance(obj2, StructuredAlias)
+        assert obj2.cls is array
+        assert obj2.args == (Header[uint32, uint8], T)
+
+        obj3 = obj2.resolve({T: self.Item})
+        assert obj3 is array[Header[uint32, uint8], self.Item]
+        assert obj.resolve(self.tvar_map) is array[Header[uint32, uint8], self.Item]
+
+
+def test_automatic_resolution():
+    class Item(Structured):
+        a: int8
+
+    class Base(Generic[_Size, T, U, V], Structured):
+        a: _Size
+        b: unicode[U]
+        c: array[Header[1, V], T]
+
+    class PartiallySpecialized(Generic[U, T], Base[uint8, T, uint32, U]): pass
+    class FullySpecialized1(Base[uint8, Item, uint32, uint16]): pass
+    class FullySpecialized2(PartiallySpecialized[uint16, Item]): pass
+
+    assert PartiallySpecialized.attrs == ('a', 'b')
+    hints = get_type_hints(PartiallySpecialized)
+    assert hints['a'] is uint8
+    assert hints['b'] is unicode[uint32]
+    assert isinstance(hints['c'], StructuredAlias)
+
+    assert FullySpecialized1.attrs == FullySpecialized2.attrs
+    assert FullySpecialized1.attrs == ('a', 'b', 'c')
+    assert get_type_hints(FullySpecialized1) == get_type_hints(FullySpecialized2)

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -1,0 +1,23 @@
+import struct
+from structured import *
+from typing import Generic, TypeVar, Union
+
+_Byte = TypeVar('_Byte', bound=Union[uint8, int8])
+_String = TypeVar('_String', bound=Union[char, pascal, unicode])
+
+
+class Base(Generic[_Byte, _String], Structured):
+    a: _Byte
+    b: _String
+
+
+class UnsignedUnicode(Base[uint8, unicode[uint8]]):
+    pass
+
+
+def test_generics() -> None:
+    obj = UnsignedUnicode(10, 'Hello')
+    target_data = struct.pack('BB5s', 10, 5, b'Hello')
+
+    # pack/unpack
+    assert obj.pack() == target_data

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,1 +1,3 @@
 from structured import *
+
+# No tests at the moment


### PR DESCRIPTION
Parially implements #8

Generics in Structured classes require subclassing to detect the specialized version, due to interactions with `Generic`s version of `__class_getitem__` and wanting to return the specialized class in that.