### PR TITLE
Typing improvements

### DIFF
--- a/structured/__init__.py
+++ b/structured/__init__.py
@@ -1,10 +1,10 @@
 __author__ = 'lojack5'
 __version__ = '2.0.2'
 
-from .structured import *
-from .basic_types import *
 from .base_types import (
-    Serializer, StructSerializer, StructActionSerializer, CompoundSerializer,
-    ByteOrder, ByteOrderMode,
+    ByteOrder, ByteOrderMode, CompoundSerializer, Serializer,
+    StructActionSerializer, StructSerializer,
 )
+from .basic_types import *
 from .complex_types import *
+from .structured import *

--- a/structured/base_types.py
+++ b/structured/base_types.py
@@ -56,7 +56,7 @@ from enum import Enum
 from .utils import specialized
 from .type_checking import (
     ClassVar, Callable, Any, _T, ReadableBuffer, WritableBuffer, SupportsRead,
-    SupportsWrite,
+    SupportsWrite, Annotated,
 )
 
 
@@ -125,7 +125,7 @@ class counted(format_type):
         @specialized(cls, count)
         class _counted(cls):
             format: ClassVar[str] = f'{count}{cls.format}'
-        return _counted
+        return Annotated[cls, _counted]
 
 
 class Serializer(structured_type):

--- a/structured/base_types.py
+++ b/structured/base_types.py
@@ -84,6 +84,9 @@ class ByteOrderMode(str, Enum):
 
 
 def noop_action(x: _T) -> _T:
+    """A noop for StructActionSerializers where no additional wrapping is
+    needed.
+    """
     return x
 
 

--- a/structured/base_types.py
+++ b/structured/base_types.py
@@ -43,21 +43,23 @@ provide the following methods and attributes:
             - unpack_from
             - pack_into
           This is to support dynamically sized packing/unpacking.
+          NOTE: Serializer objects are shared between class objects, so this
+          is only up to date with the most recent call amongst all objects
+          sharing the serializer.
 """
 from __future__ import annotations
 
-
 import struct
-from functools import cache, wraps
-from itertools import chain
-from io import BytesIO
 from enum import Enum
+from functools import cache, wraps
+from io import BytesIO
+from itertools import chain
 
-from .utils import specialized
 from .type_checking import (
-    ClassVar, Callable, Any, _T, ReadableBuffer, WritableBuffer, SupportsRead,
-    SupportsWrite, Annotated,
+    _T, Annotated, Any, Callable, ClassVar, ReadableBuffer, SupportsRead,
+    SupportsWrite, WritableBuffer,
 )
+from .utils import specialized
 
 
 class ByteOrder(str, Enum):

--- a/structured/basic_types.py
+++ b/structured/basic_types.py
@@ -20,7 +20,9 @@ from functools import cache
 
 from .base_types import format_type, counted, noop_action
 from .utils import specialized
-from .type_checking import ClassVar, Callable, Any
+from .type_checking import (
+    ClassVar, Callable, Any, Annotated, get_args, get_origin, Union, Container,
+)
 
 
 class pad(counted):
@@ -30,64 +32,86 @@ class pad(counted):
     format: ClassVar[str] = 'x'
 
 
-class bool8(int, format_type):
+class _bool8(format_type):
     """bool struct type, stored as an integer: '?'."""
     format: ClassVar[str] = '?'
+bool8 = Annotated[int, _bool8]
 
 
-class int8(int, format_type):
+class _int8(format_type):
     """8-bit signed integer: 'b'."""
     format: ClassVar[str] = 'b'
+int8 = Annotated[int, _int8]
 
 
-class uint8(int, format_type):
+class _uint8(format_type):
     """8-bit unsigned integer: 'B'. """
     format: ClassVar[str] = 'B'
+uint8 = Annotated[int, _uint8]
 
 
-class int16(int, format_type):
+class _int16(format_type):
     """16-bit signed integer: 'h'."""
     format: ClassVar[str] = 'h'
+int16 = Annotated[int, _int16]
 
 
-class uint16(int, format_type):
+class _uint16(format_type):
     """16-bit unsigned integer: 'H'."""
     format: ClassVar[str] = 'H'
+uint16 = Annotated[int, _uint16]
 
 
-class int32(int, format_type):
+class _int32(format_type):
     """32-bit signed integer."""
     format: ClassVar[str] = 'i'
+int32 = Annotated[int, _int32]
 
 
-class uint32(int, format_type):
+class _uint32(format_type):
     """32-bit unsigned integer: 'I'."""
     format: ClassVar[str] = 'I'
+uint32 = Annotated[int, _uint32]
 
 
-class int64(int, format_type):
+class _int64(format_type):
     """64-bit signed integer: 'q'."""
     format: ClassVar[str] = 'q'
+int64 = Annotated[int, _int64]
 
 
-class uint64(int, format_type):
+class _uint64(format_type):
     """64-bit unsigned integer: 'Q'."""
     format: ClassVar[str] = 'Q'
+uint64 = Annotated[int, _uint64]
 
 
-class float16(float, format_type):
+class _float16(format_type):
     """IEEE 754 16-bit half-precision floating point number."""
     format: ClassVar[str] = 'e'
+float16 = Annotated[float, _float16]
 
 
-class float32(float, format_type):
+class _float32(format_type):
     """IEEE 754 32-bit floating point number."""
     format: ClassVar[str] = 'f'
+float32 = Annotated[float, _float32]
 
 
-class float64(float, format_type):
+class _float64(format_type):
     """IEEE 754 64-bit double-precision floating point number."""
     format: ClassVar[str] = 'd'
+float64 = Annotated[float, _float64]
+
+
+def unwrap_annotated(x: Any) -> Any:
+    if get_origin(x) is Annotated:
+        for meta in (args := get_args(x)):
+            if isinstance(meta, type) and issubclass(meta, format_type):
+                return meta
+        else:
+            return args[0]
+    return x
 
 
 # NOTE: char moved to complex_types/unicode.py, since it can optionally
@@ -101,7 +125,13 @@ class pascal(str, counted):
     format: ClassVar[str] = 'p'
 
 
-
+TTypes = Union[
+    # Can be exactly one of the Annotated types
+    bool8, int8, uint8, int16, uint16, int32, uint32, int64, uint64, float16,
+    float32, float64,
+    # Or any format_type
+    format_type,
+]
 class Formatted(format_type):
     """Class used for creating new `format_type`s.  Provides a class getitem
     to select the format specifier, by grabbing from one of the provided format
@@ -109,7 +139,7 @@ class Formatted(format_type):
 
     For examples of how to use this, see `TestFormatted`.
     """
-    _types: ClassVar[frozenset[type[format_type]]] = frozenset()
+    _types: ClassVar[Container[TTypes]] = frozenset()
 
     @classmethod    # Need to remark as classmethod since we're caching
     @cache
@@ -117,22 +147,26 @@ class Formatted(format_type):
             cls: type[Formatted],
             key: type[format_type],
         ) -> type[Formatted]:
+        unwrapped = unwrap_annotated(key)
         # Error checking
-        if not issubclass(key, format_type):
+        if not issubclass(unwrapped, format_type):
             raise TypeError(
                 f'Formatted key must be a format_type, got {key!r}.'
             )
         if cls._types is Formatted._types:
             # Default, just allow any format type
-            fmt = key.format
+            fmt = unwrapped.format
         else:
             # Overridden _types, get from that set
-            if key not in cls._types:
+            # NOTE: users may do _types = {int8, ...}
+            # So we need to check both the actual key and it's unwrapped
+            # version
+            if key not in cls._types and unwrapped not in cls._types:
                 raise TypeError(
                     'Formatted key must be one of the allowed types of '
                     f'{cls.__qualname__}.'
                 )
-            fmt = key.format
+            fmt = unwrapped.format
         action = getattr(cls, 'unpack_action', noop_action)
         # Create the subclass
         @specialized(cls, key)

--- a/structured/basic_types.py
+++ b/structured/basic_types.py
@@ -2,8 +2,6 @@
 All of the basic format types that map directly to struct format specifiers.
 """
 from __future__ import annotations
-from itertools import chain
-
 
 __all__ = [
     'pad', 'bool8',
@@ -16,14 +14,14 @@ __all__ = [
     'Formatted',
 ]
 
-
 from functools import cache
+from itertools import chain
 
-from .base_types import format_type, counted, noop_action, Serializer
-from .utils import specialized, StructuredAlias
+from .base_types import Serializer, counted, format_type, noop_action
 from .type_checking import (
-    ClassVar, Callable, Any, Annotated, get_args, get_origin, Union, Container,
+    Annotated, Any, Callable, ClassVar, Container, Union, get_args, get_origin,
 )
+from .utils import StructuredAlias, specialized
 
 
 class pad(counted):

--- a/structured/basic_types.py
+++ b/structured/basic_types.py
@@ -20,7 +20,7 @@ __all__ = [
 from functools import cache
 
 from .base_types import format_type, counted, noop_action, Serializer
-from .utils import specialized
+from .utils import specialized, StructuredAlias
 from .type_checking import (
     ClassVar, Callable, Any, Annotated, get_args, get_origin, Union, Container,
 )
@@ -134,6 +134,8 @@ def unwrap_annotated(x: Any) -> Any:
                 # could show up like this:
                 # b: Annotated[int, int8]
                 if isinstance(meta, type) and issubclass(meta, (format_type, Serializer)):
+                    return meta
+                elif isinstance(meta, StructuredAlias):
                     return meta
             else:
                 return args[0]

--- a/structured/basic_types.py
+++ b/structured/basic_types.py
@@ -107,6 +107,9 @@ float64 = Annotated[float, _float64]
 def unwrap_annotated(x: Any) -> Any:
     if get_origin(x) is Annotated:
         for meta in (args := get_args(x)):
+            meta = unwrap_annotated(meta)   # Handle nested Annotateds, which
+            # could show up like this:
+            # b: Annotated[int, int8]
             if isinstance(meta, type) and issubclass(meta, format_type):
                 return meta
         else:

--- a/structured/complex_types/array_headers.py
+++ b/structured/complex_types/array_headers.py
@@ -7,10 +7,10 @@ from __future__ import annotations
 
 from functools import cache
 
-from ..utils import StructuredAlias, specialized
-from ..structured import Structured
 from ..basic_types import _uint8, _uint16, _uint32, _uint64, unwrap_annotated
-from ..type_checking import ClassVar, Union, Generic, Optional, TypeVar
+from ..structured import Structured
+from ..type_checking import ClassVar, Generic, Optional, TypeVar, Union
+from ..utils import StructuredAlias, specialized
 
 
 _SizeTypes = (_uint8, _uint16, _uint32, _uint64)

--- a/structured/complex_types/array_headers.py
+++ b/structured/complex_types/array_headers.py
@@ -9,12 +9,12 @@ from functools import cache
 
 from ..utils import StructuredAlias, specialized
 from ..structured import Structured
-from ..basic_types import uint8, uint16, uint32, uint64
+from ..basic_types import _uint8, _uint16, _uint32, _uint64, unwrap_annotated
 from ..type_checking import ClassVar, Union, Generic, Optional, TypeVar
 
 
-_SizeTypes = (uint8, uint16, uint32, uint64)
-SizeTypes = Union[uint8, uint16, uint32, uint64]
+_SizeTypes = (_uint8, _uint16, _uint32, _uint64)
+SizeTypes = Union[_uint8, _uint16, _uint32, _uint64]
 TSize = TypeVar('TSize', bound=SizeTypes)
 TCount = TypeVar('TCount', bound=SizeTypes)
 
@@ -183,7 +183,7 @@ class Header(Structured, HeaderBase):
         """
         if not isinstance(key, tuple):
             key = (key, )
-        return cls.create(*key)
+        return cls.create(*map(unwrap_annotated, key))
 
     @classmethod
     def create(cls, count, size_check=None):

--- a/structured/complex_types/arrays.py
+++ b/structured/complex_types/arrays.py
@@ -17,6 +17,7 @@ from ..base_types import (
     Serializer, StructSerializer, format_type, requires_indexing, struct_cache,
     ByteOrder,
 )
+from ..basic_types import *
 from ..utils import specialized
 from ..type_checking import (
     Union, ReadableBuffer, WritableBuffer, SupportsRead, SupportsWrite, Any,
@@ -25,7 +26,15 @@ from ..type_checking import (
 
 
 T = TypeVar('T', bound=Header)
-U = TypeVar('U', bound=Union[format_type, Structured])
+U = TypeVar('U',
+    # Any of the Annotated types
+    bool8, int8, uint8, int16, uint16, int32, uint32, int64, uint64, float16,
+    float32, float64,
+    # Or any format_type or a Structured type
+    format_type, Structured,
+    covariant=True,
+    #bound=Union[format_type, Structured],
+)
 
 
 class array(list[U], requires_indexing, Generic[T, U]):
@@ -69,6 +78,7 @@ class array(list[U], requires_indexing, Generic[T, U]):
         """Perform error checks and dispatch to the applicable class factory."""
         if not isinstance(args, tuple) or len(args) < 2:
             cls.error(TypeError, 'expected 2 arguments')
+        args = tuple(map(unwrap_annotated, args))
         if len(args) == 2:
             header, array_type = args
         else:

--- a/structured/complex_types/arrays.py
+++ b/structured/complex_types/arrays.py
@@ -25,6 +25,10 @@ from .array_headers import *
 
 
 T = TypeVar('T', bound=Header)
+
+# Unsure if this works as indended:  The passed type should be one of the
+# basic types, or derived from format_type (like pad, char, etc), or derived
+# from Structured.
 U = TypeVar('U',
     # Any of the Annotated types
     bool8, int8, uint8, int16, uint16, int32, uint32, int64, uint64, float16,
@@ -108,7 +112,7 @@ class array(list[U], requires_indexing, Generic[T, U]):
     def _create(
             cls,
             header: type[Header],
-            array_type: type[U],
+            array_type,     # TODO: proper annotation?
         ) -> type[list[U]]:
         """Actual creation of the header."""
         if issubclass(array_type, format_type):

--- a/structured/complex_types/arrays.py
+++ b/structured/complex_types/arrays.py
@@ -21,7 +21,7 @@ from ..basic_types import *
 from ..utils import specialized
 from ..type_checking import (
     Union, ReadableBuffer, WritableBuffer, SupportsRead, SupportsWrite, Any,
-    NoReturn, ClassVar, Generic, TypeVar,
+    NoReturn, ClassVar, Generic, TypeVar, Annotated,
 )
 
 
@@ -124,20 +124,20 @@ class array(list[U], requires_indexing, Generic[T, U]):
                 class _array1(_format_array):
                     count: ClassVar[int] = header._count
                     obj_type: ClassVar[type[format_type]] = array_type
-                return _array1
+                return Annotated[list[U], _array1]
             else:
                 count = get_type_hints(header)['count']
                 @specialized(cls, header, array_type)
                 class _array2(_dynamic_format_array):
                     count_type: ClassVar[type[SizeTypes]] = count
                     obj_type: ClassVar[type[format_type]] = array_type
-                return _array2
+                return Annotated[list[U], _array2]
         else:
             @specialized(cls, header, array_type)
             class _array3(_structured_array):
                 header_type: ClassVar[type[Header]] = header
                 obj_type: ClassVar[type[Structured]] = array_type
-            return _array3
+            return Annotated[list[U], _array3]
 
 
 class _structured_array(Serializer):

--- a/structured/complex_types/arrays.py
+++ b/structured/complex_types/arrays.py
@@ -74,7 +74,7 @@ class array(list[U], requires_indexing, Generic[T, U]):
     def __class_getitem__(
             cls,
             args: tuple[type[T], type[U]]
-        ) -> type[Serializer]:
+        ) -> type[list[U]]:
         """Perform error checks and dispatch to the applicable class factory."""
         if not isinstance(args, tuple) or len(args) < 2:
             cls.error(TypeError, 'expected 2 arguments')
@@ -109,8 +109,8 @@ class array(list[U], requires_indexing, Generic[T, U]):
     def _create(
             cls,
             header: type[Header],
-            array_type: type[U]
-        ) -> type[Serializer]:
+            array_type: type[U],
+        ) -> type[list[U]]:
         """Actual creation of the header."""
         if issubclass(array_type, format_type):
             if issubclass(header, (StaticCheckedHeader, DynamicCheckedHeader)):

--- a/structured/complex_types/arrays.py
+++ b/structured/complex_types/arrays.py
@@ -2,27 +2,26 @@
 Array types
 """
 from __future__ import annotations
-from typing import get_type_hints
 
 __all__ = [
     'array', 'Header',
 ]
 
 import io
-from itertools import repeat
 from functools import cache
+from itertools import repeat
 
-from .array_headers import *
 from ..base_types import (
-    Serializer, StructSerializer, format_type, requires_indexing, struct_cache,
-    ByteOrder,
+    ByteOrder, Serializer, StructSerializer, format_type, requires_indexing,
+    struct_cache,
 )
 from ..basic_types import *
-from ..utils import specialized
 from ..type_checking import (
-    Union, ReadableBuffer, WritableBuffer, SupportsRead, SupportsWrite, Any,
-    NoReturn, ClassVar, Generic, TypeVar, Annotated,
+    Annotated, Any, ClassVar, Generic, NoReturn, ReadableBuffer, SupportsRead,
+    SupportsWrite, TypeVar, WritableBuffer, get_type_hints,
 )
+from ..utils import specialized
+from .array_headers import *
 
 
 T = TypeVar('T', bound=Header)

--- a/structured/complex_types/strings.py
+++ b/structured/complex_types/strings.py
@@ -20,7 +20,7 @@ from ..base_types import (
 from ..basic_types import _uint8, _uint16, _uint32, _uint64, unwrap_annotated
 from ..type_checking import (
     ClassVar, ReadableBuffer, SupportsRead, Any, SupportsWrite, WritableBuffer,
-    Union, Callable, cast
+    Union, Callable, cast, Annotated
 )
 
 
@@ -53,7 +53,7 @@ class char(_char):
                       type[Union[uint8, uint16, uint32, uint64]],
                       type[NET]]
     """
-    def __class_getitem__(cls, args) -> type[structured_type]:
+    def __class_getitem__(cls, args) -> type[bytes]:
         """Create a char specialization."""
         if not isinstance(args, tuple):
             args = (args,)
@@ -64,7 +64,7 @@ class char(_char):
     def _create(
             cls,
             count: Union[int, type[SizeTypes], type[NET]],
-        ) -> type[structured_type]:
+        ) -> type[bytes]:
         if isinstance(count, int):
             new_cls = _char[count]
         elif isinstance(count, type) and issubclass(count, _SizeTypes):
@@ -78,7 +78,7 @@ class char(_char):
                 f'{cls.__qualname__}[] count must be an int, NET, or uint* '
                 'type.'
             )
-        return specialized(cls, count)(new_cls)
+        return Annotated[bytes, new_cls]
 
 
 class EncoderDecoder:
@@ -175,8 +175,7 @@ class unicode(str, requires_indexing):
             raise TypeError()
 
         new_cls = unicode_wrap(base, encoder, decoder)
-        return specialized(cls, count, encoding)(new_cls)
-
+        return Annotated[str, new_cls]
 
 
 class _static_char(StructSerializer):

--- a/structured/complex_types/strings.py
+++ b/structured/complex_types/strings.py
@@ -8,20 +8,19 @@ __all__ = [
     'NET',
 ]
 
-from functools import cache, partial
 import struct
-from typing import TypeVar
+from functools import cache, partial
 
-from ..utils import StructuredAlias, specialized
 from ..base_types import (
-    Serializer, StructSerializer, requires_indexing, ByteOrder, struct_cache,
-    structured_type, counted,
+    ByteOrder, Serializer, StructSerializer, counted, requires_indexing,
+    struct_cache,
 )
 from ..basic_types import _uint8, _uint16, _uint32, _uint64, unwrap_annotated
 from ..type_checking import (
-    ClassVar, ReadableBuffer, SupportsRead, Any, SupportsWrite, WritableBuffer,
-    Union, Callable, cast, Annotated
+    Annotated, Any, Callable, ClassVar, ReadableBuffer, SupportsRead,
+    SupportsWrite, TypeVar, Union, WritableBuffer, cast,
 )
+from ..utils import StructuredAlias
 
 
 _SizeTypes = (_uint8, _uint16, _uint32, _uint64)    # py 3.9 isinstance/subclass

--- a/structured/complex_types/strings.py
+++ b/structured/complex_types/strings.py
@@ -121,7 +121,7 @@ class unicode(str, requires_indexing):
     :type encoding: Union[str, type[EncoderDecoder]]
     """
     @classmethod
-    def __class_getitem__(cls, args) -> type[Serializer]:
+    def __class_getitem__(cls, args) -> type[str]:
         """Create the specialization."""
         if not isinstance(args, tuple):
             args = (args, )
@@ -137,7 +137,7 @@ class unicode(str, requires_indexing):
             cls,
             count: Union[int, type[SizeTypes], type[NET]],
             encoding: Union[str, type[EncoderDecoder]] = 'utf8',
-        ) -> type[Serializer]:
+        ) -> type[str]:
         return cls._create(count, encoding)
 
     @classmethod
@@ -146,7 +146,7 @@ class unicode(str, requires_indexing):
             cls,
             count: Union[int, type[SizeTypes], type[NET]],
             encoding: Union[str, type[EncoderDecoder]],
-        ) -> type[Serializer]:
+        ) -> type[str]:
         """Create the specialization.
 
         :param count: Size of the *encoded* string.

--- a/structured/complex_types/strings.py
+++ b/structured/complex_types/strings.py
@@ -17,15 +17,15 @@ from ..base_types import (
     Serializer, StructSerializer, requires_indexing, ByteOrder, struct_cache,
     structured_type, counted,
 )
-from ..basic_types import uint8, uint16, uint32, uint64
+from ..basic_types import _uint8, _uint16, _uint32, _uint64, unwrap_annotated
 from ..type_checking import (
     ClassVar, ReadableBuffer, SupportsRead, Any, SupportsWrite, WritableBuffer,
     Union, Callable, cast
 )
 
 
-_SizeTypes = (uint8, uint16, uint32, uint64)    # py 3.9 isinstance/subclass
-SizeTypes = Union[uint8, uint16, uint32, uint64]
+_SizeTypes = (_uint8, _uint16, _uint32, _uint64)    # py 3.9 isinstance/subclass
+SizeTypes = Union[_uint8, _uint16, _uint32, _uint64]
 Encoder = Callable[[str], bytes]
 Decoder = Callable[[bytes], str]
 
@@ -57,7 +57,7 @@ class char(_char):
         """Create a char specialization."""
         if not isinstance(args, tuple):
             args = (args,)
-        return cls._create(*args)
+        return cls._create(*map(unwrap_annotated, args))
 
     @classmethod
     @cache
@@ -130,7 +130,7 @@ class unicode(str, requires_indexing):
         # _create(uint8, 'utf8')
         # technically are different call types, so the cache isn't hit.
         # Pass through an intermediary to take care of this.
-        return cls.create(*args)
+        return cls.create(*map(unwrap_annotated, args))
 
     @classmethod
     def create(

--- a/structured/structured.py
+++ b/structured/structured.py
@@ -1,9 +1,4 @@
 from __future__ import annotations
-import operator
-from typing import get_args, get_origin
-import typing
-
-from structured.utils import StructuredAlias
 
 __all__ = [
     'Structured',
@@ -12,20 +7,25 @@ __all__ = [
     'create_serializer',
 ]
 
-from functools import reduce
+import operator
 import re
+from functools import reduce
+
+from structured.utils import StructuredAlias
 
 from .base_types import *
 from .basic_types import pad, unwrap_annotated
-from .utils import deprecated
 from .type_checking import (
-    Any, ClassVar, Optional, ReadableBuffer, SupportsRead, SupportsWrite,
-    WritableBuffer, get_type_hints, isclassvar, cast, TypeGuard, Union, TypeVar,
-    get_annotations, update_annotations,
+    Any, ClassVar, Generic, Optional, ReadableBuffer, SupportsRead,
+    SupportsWrite, TypeGuard, TypeVar, Union, WritableBuffer, cast,
+    get_annotations, get_args, get_origin, get_type_hints, isclassvar,
+    update_annotations,
 )
+from .utils import deprecated
 
 
 _Annotation = Union[format_type, Serializer]
+
 
 def validate_typehint(attr_type: type) -> TypeGuard[type[_Annotation]]:
     if isclassvar(attr_type):
@@ -439,7 +439,7 @@ class Structured:
         supers: dict[type[Structured], Any] = {}
         tvars = ()
         for base in getattr(cls, '__orig_bases__', ()):
-            if (origin := get_origin(base)) is typing.Generic:
+            if (origin := get_origin(base)) is Generic:
                 tvars = get_args(base)
             elif origin and issubclass(origin, Structured):
                 supers[origin] = base

--- a/structured/structured.py
+++ b/structured/structured.py
@@ -43,7 +43,7 @@ def validate_typehint(attr_type: type) -> TypeGuard[type[_Annotation]]:
     return False
 
 
-@deprecated('2.1.0', issue=5, use_instead='Annotated[unpacked_type, kind]')
+@deprecated('2.1.0', '3.0', issue=5, use_instead='Annotated[unpacked_type, kind]')
 def serialized(kind: type[structured_type]) -> Any:
     """Type erasure for class definitions, allowing for linters to pick up the
     correct final type.  For example:

--- a/structured/structured.py
+++ b/structured/structured.py
@@ -452,14 +452,16 @@ class Structured:
         cls_annotations = get_annotations(cls)
         for attr, attr_type in get_type_hints(cls, include_extras=True).items():
             if attr in cls_annotations:
+                unwrapped = unwrap_annotated(attr_type)
                 # Attribute's final type hint comes from this class
-                if remapped_type := tvar_map.get(attr_type, None):
+                if remapped_type := tvar_map.get(unwrapped, None):
                     annotations[attr] = remapped_type
-                elif isinstance(attr_type, StructuredAlias):
-                    annotations[attr] = attr_type.resolve(tvar_map)
+                elif isinstance(unwrapped, StructuredAlias):
+                    annotations[attr] = unwrapped.resolve(tvar_map)
         for attr, attr_val in cls.__dict__.items():
-            if isinstance(attr_val, StructuredAlias):
-                classdict[attr] = attr_val.resolve(tvar_map)
+            unwrapped = unwrap_annotated(attr_val)
+            if isinstance(unwrapped, StructuredAlias):
+                classdict[attr] = unwrapped.resolve(tvar_map)
         # Now any classes higher in the chain
         all_annotations = [annotations]
         all_classdict = [classdict]

--- a/structured/structured.py
+++ b/structured/structured.py
@@ -445,7 +445,7 @@ class Structured:
                 supers[origin] = base
         tvar_map = dict(zip(tvars, args))
         if not tvar_map:
-            raise TypeError('{cls.__name__} is not a Generic')
+            raise TypeError(f'{cls.__name__} is not a Generic')
         # First handle the direct base class
         annotations = {}
         classdict = {}

--- a/structured/structured.py
+++ b/structured/structured.py
@@ -17,6 +17,7 @@ import re
 
 from .base_types import *
 from .basic_types import pad, unwrap_annotated
+from .utils import deprecated
 from .type_checking import (
     Any, ClassVar, Optional, ReadableBuffer, SupportsRead, SupportsWrite,
     WritableBuffer, get_type_hints, isclassvar, cast, TypeGuard, Union, TypeVar,
@@ -42,6 +43,7 @@ def validate_typehint(attr_type: type) -> TypeGuard[type[_Annotation]]:
     return False
 
 
+@deprecated('2.1.0', issue=5, use_instead='Annotated[unpacked_type, kind]')
 def serialized(kind: type[structured_type]) -> Any:
     """Type erasure for class definitions, allowing for linters to pick up the
     correct final type.  For example:

--- a/structured/type_checking.py
+++ b/structured/type_checking.py
@@ -1,8 +1,9 @@
 import sys
 import typing
 from typing import (
-    Any, Callable, ClassVar, Optional, Protocol, TypeVar, Union, Generic,
-    get_origin, get_type_hints, runtime_checkable, NoReturn, cast,
+    Annotated, Any, Callable, ClassVar, Generic, NoReturn, Optional, Protocol,
+    TypeVar, Union, cast, get_args, get_origin, get_type_hints,
+    runtime_checkable, Container,
 )
 
 if sys.version_info < (3, 10):
@@ -85,10 +86,10 @@ SupportsWrite: TypeAlias = Union[_SupportsWrite1, _SupportsWrite2]
 if typing.TYPE_CHECKING:
     import array
     import ctypes
+    import io
     import mmap
     import pickle
     import sys
-    import io
     from typing import Any
 
     ReadOnlyBuffer: TypeAlias = bytes

--- a/structured/type_checking.py
+++ b/structured/type_checking.py
@@ -1,15 +1,15 @@
 import sys
 import typing
 from typing import (
-    Annotated, Any, Callable, ClassVar, Generic, NoReturn, Optional, Protocol,
-    TypeVar, Union, cast, get_args, get_origin, get_type_hints,
-    runtime_checkable, Container,
+    Annotated, Any, Callable, ClassVar, Container, Generic, NoReturn, Optional,
+    Protocol, TypeVar, Union, cast, get_args, get_origin, get_type_hints,
+    runtime_checkable,
 )
 
 if sys.version_info < (3, 10):
-    from typing_extensions import TypeAlias, TypeGuard
+    from typing_extensions import ParamSpec, TypeAlias, TypeGuard
 else:
-    from typing import TypeAlias, TypeGuard
+    from typing import ParamSpec, TypeAlias, TypeGuard
 
 
 _T = TypeVar('_T')

--- a/structured/utils.py
+++ b/structured/utils.py
@@ -1,8 +1,10 @@
 """
 Various utility methods.
 """
-from typing import TypeVar
-from .type_checking import _T, NoReturn, Any, Callable
+import warnings
+from typing import ParamSpec, TypeVar
+from functools import wraps
+from .type_checking import _T, NoReturn, Any, Callable, Optional
 
 
 @classmethod
@@ -62,3 +64,67 @@ class StructuredAlias:
             return StructuredAlias(self.cls, resolved)
         else:
             return self.cls[resolved]   # type: ignore
+
+
+# nice deprecation warnings, ideas from Trio
+class StructuredDeprecationWarning(FutureWarning):
+    """Warning emitted if you use deprecated Structured functionality. This
+    feature will be removed in a future version. Despite the name, this class
+    currently inherits from :class:`FutureWarning`, not
+    :class:`DeprecationWarning`, because we want these warning to be visible by
+    default. You can hide them by installing a filter or with the ``-W``
+    switch.
+    """
+
+
+def _stringify(x: Any) -> str:
+    if hasattr(x, '__module__') and hasattr(x, '__qualname__'):
+        return f'{x.__module__}.{x.__qualname__}'
+    else:
+        return str(x)
+
+def _issue_url(issue: int) -> str:
+    return f'https://github.com/lojack5/structured/issuespython-trio/trio/issues/{issue}'
+
+def warn_deprecated(x: Any, version: str, *, issue: Optional[int], use_instead: Any, stacklevel: int = 2) -> None:
+    stacklevel += 1
+    msg = f'{_stringify(x)} is deprecated since Structured {version}'
+    if use_instead is None:
+        msg += ' with no replacement'
+    else:
+        msg += f'; use {_stringify(use_instead)} instead'
+    if issue is not None:
+        msg += f' ({_issue_url(issue)})'
+    warnings.warn(StructuredDeprecationWarning(msg), stacklevel=stacklevel)
+
+
+P = ParamSpec('P')
+T = TypeVar('T')
+# @deprecated("0.2.0", issue=..., use_instead=...)
+def deprecated(version: str, *, x: Any = None, issue: int, use_instead: Any) -> Callable[[Callable[P, T]], Callable[P, T]]:
+    def inner(fn: Callable[P, T]) -> Callable[P, T]:
+        nonlocal x
+
+        @wraps(fn)
+        def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+            warn_deprecated(x, version, use_instead=use_instead, issue=issue)
+            return fn(*args, **kwargs)
+
+        # If our __module__ or __qualname__ get modified, we want to pick up
+        # on that, so we read them off the wrapper object instead of the (now
+        # hidden) fn object
+        if x is None:
+            x = wrapper
+
+        if wrapper.__doc__ is not None:
+            doc = wrapper.__doc__
+            doc = doc.rstrip() + f'\n\n .. deprecated:: {version}\n'
+            if use_instead is not None:
+                doc += f'   Use {_stringify(use_instead)} instead.\n'
+            if issue is not None:
+                doc += f'   For details, see `issue #{issue} <{_issue_url(issue)}>`__.\n'
+            doc += '\n'
+            wrapper.__doc__ = doc
+
+        return wrapper
+    return inner

--- a/structured/utils.py
+++ b/structured/utils.py
@@ -2,9 +2,11 @@
 Various utility methods.
 """
 import warnings
-from typing import ParamSpec, TypeVar
 from functools import wraps
-from .type_checking import _T, NoReturn, Any, Callable, Optional
+
+from .type_checking import (
+    _T, Any, Callable, NoReturn, Optional, ParamSpec, TypeVar,
+)
 
 
 @classmethod

--- a/structured/utils.py
+++ b/structured/utils.py
@@ -86,9 +86,9 @@ def _stringify(x: Any) -> str:
 def _issue_url(issue: int) -> str:
     return f'https://github.com/lojack5/structured/issuespython-trio/trio/issues/{issue}'
 
-def warn_deprecated(x: Any, version: str, *, issue: Optional[int], use_instead: Any, stacklevel: int = 2) -> None:
+def warn_deprecated(x: Any, version: str, removal: str, *, issue: Optional[int], use_instead: Any, stacklevel: int = 2) -> None:
     stacklevel += 1
-    msg = f'{_stringify(x)} is deprecated since Structured {version}'
+    msg = f'{_stringify(x)} is deprecated since structured-classes {version} and will be removed in structured-classes {removal}'
     if use_instead is None:
         msg += ' with no replacement'
     else:
@@ -101,13 +101,13 @@ def warn_deprecated(x: Any, version: str, *, issue: Optional[int], use_instead: 
 P = ParamSpec('P')
 T = TypeVar('T')
 # @deprecated("0.2.0", issue=..., use_instead=...)
-def deprecated(version: str, *, x: Any = None, issue: int, use_instead: Any) -> Callable[[Callable[P, T]], Callable[P, T]]:
+def deprecated(version: str, removal: str, *, x: Any = None, issue: int, use_instead: Any) -> Callable[[Callable[P, T]], Callable[P, T]]:
     def inner(fn: Callable[P, T]) -> Callable[P, T]:
         nonlocal x
 
         @wraps(fn)
         def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
-            warn_deprecated(x, version, use_instead=use_instead, issue=issue)
+            warn_deprecated(x, version, removal, use_instead=use_instead, issue=issue)
             return fn(*args, **kwargs)
 
         # If our __module__ or __qualname__ get modified, we want to pick up

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
-from typing import Annotated, ClassVar, get_type_hints
+from typing import Annotated, ClassVar, get_origin, get_type_hints
 
 from structured import *
-from structured.basic_types import unwrap_annotated, _int8
+from structured.basic_types import (
+    unwrap_annotated, _int8, _AnnotatedTypes, _UnAnnotatedTypes,
+)
+from structured.base_types import format_type, requires_indexing
 
 
 def test_eval_annotation() -> None:
@@ -25,6 +28,32 @@ def test_unwrap_annotated() -> None:
     assert unwrap_annotated(hints['b']) is _int8
     assert unwrap_annotated(hints['c']) is int
     assert unwrap_annotated(hints['d']) is int
+
+
+def test_for_annotated() -> None:
+    """Ensure all usable types are an Annotated, with a few exceptions.
+
+    Current exceptsion are unindexed pad, char, and unicode.
+    """
+    # Basic types
+    for kind in _AnnotatedTypes:
+        assert get_origin(kind) is Annotated
+    for kind in _UnAnnotatedTypes:
+        assert get_origin(kind) is not Annotated
+        assert issubclass(kind, format_type)
+    # Complex types: array
+    assert get_origin(array) is not Annotated
+    assert get_origin(array[Header[1], int8]) is Annotated
+    # Complex types: char
+    assert get_origin(char) is not Annotated
+    assert issubclass(char, format_type)
+    assert get_origin(char[10]) is Annotated
+    assert get_origin(char[uint32]) is Annotated
+    # Complex types: unicode
+    assert get_origin(unicode) is not Annotated
+    assert issubclass(unicode, requires_indexing)
+    assert get_origin(unicode[10]) is Annotated
+    assert get_origin(unicode[uint32]) is Annotated
 
 
 class A: pass

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import ClassVar
+from typing import Annotated, ClassVar, get_type_hints
 
 from structured import *
+from structured.basic_types import unwrap_annotated, _int8
 
 
 def test_eval_annotation() -> None:
@@ -10,6 +11,20 @@ def test_eval_annotation() -> None:
     class Base(Structured):
         a: ClassVar[A]
         b: int8
+
+
+def test_unwrap_annotated() -> None:
+    class A:
+        a: int8
+        b: Annotated[int, int8]
+        c: int
+        d: Annotated[int, 'foo']
+
+    hints = get_type_hints(A, include_extras=True)
+    assert unwrap_annotated(hints['a']) is _int8
+    assert unwrap_annotated(hints['b']) is _int8
+    assert unwrap_annotated(hints['c']) is int
+    assert unwrap_annotated(hints['d']) is int
 
 
 class A: pass

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -9,6 +9,9 @@ from structured.basic_types import (
 from structured.base_types import format_type, requires_indexing
 
 
+class A: pass
+
+
 def test_eval_annotation() -> None:
     # Prior versions of the code would fail to evaluate `ClassVar[A]`
     class Base(Structured):
@@ -56,4 +59,13 @@ def test_for_annotated() -> None:
     assert get_origin(unicode[uint32]) is Annotated
 
 
-class A: pass
+def test_alternate_syntax() -> None:
+    # Test using only Annotated
+    class Base(Structured):
+        a: Annotated[int, int8]
+        b: Annotated[bytes, char[10]]
+        c: Annotated[str, unicode[15]]
+        d: Annotated[list[int8], array[Header[2], int8]]
+        e: Annotated[None, pad[3]]
+    assert Base.attrs == ('a', 'b', 'c', 'd', )
+

--- a/tests/test_arrays.py
+++ b/tests/test_arrays.py
@@ -220,7 +220,7 @@ def test_static_checked_structured(items: list[Item]):
         target_obj.pack()
 
     # Test malformed data_size
-    st = struct.Struct(uint32.format)
+    st = struct.Struct('I')
     st.pack_into(buffer, 0, 0)
     with pytest.raises(ValueError):
         Compound.create_unpack_from(buffer)

--- a/tests/test_base_types.py
+++ b/tests/test_base_types.py
@@ -41,7 +41,7 @@ class TestFormatted:
                 else:
                     return self._value == other
 
-        assert MutableType[int16].format == int16.format
+        assert MutableType[int16].format == 'h'
         assert MutableType[int16].unpack_action is MutableType[int16]
 
         class Base(Structured):
@@ -103,7 +103,7 @@ class TestFormatted:
     def test_subclassing_specialized(self) -> None:
         class MutableType(Formatted):
             _types = frozenset({int8, int16})
-        assert MutableType[int8].format == int8.format
+        assert MutableType[int8].format == 'b'
         assert MutableType[int8].unpack_action is MutableType[int8]
 
     def test_errors(self) -> None:

--- a/tests/test_base_types.py
+++ b/tests/test_base_types.py
@@ -3,13 +3,14 @@ import io
 import pytest
 
 from structured import *
+from structured.basic_types import unwrap_annotated
 
 
 ## Only tests needed for lines not tested by Structured tests
 
 
 def test_counted() -> None:
-    cls = pad[2]
+    cls = unwrap_annotated(pad[2])
     assert cls.format == '2x'
     assert cls.__qualname__ == 'pad[2]'
 

--- a/tests/test_generics.py
+++ b/tests/test_generics.py
@@ -7,9 +7,9 @@ from structured import *
 from structured.utils import StructuredAlias
 
 
-_Byte = TypeVar('_Byte', bound=Union[uint8, int8])
+_Byte = TypeVar('_Byte', uint8, int8)
 _String = TypeVar('_String', bound=Union[char, pascal, unicode])
-_Size = TypeVar('_Size', bound=Union[uint8, uint16, uint32, uint64])
+_Size = TypeVar('_Size', uint8, uint16, uint32, uint64)
 T = TypeVar('T', bound=Structured)
 U = TypeVar('U')
 V = TypeVar('V')
@@ -100,7 +100,7 @@ def test_automatic_resolution():
     class FullySpecialized2(PartiallySpecialized[uint16, Item]): pass
 
     assert PartiallySpecialized.attrs == ('a', 'b')
-    hints = get_type_hints(PartiallySpecialized)
+    hints = get_type_hints(PartiallySpecialized, include_extras=True)
     assert hints['a'] is uint8
     assert hints['b'] is unicode[uint32]
     assert isinstance(hints['c'], StructuredAlias)

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -4,6 +4,7 @@ import struct
 import pytest
 
 from structured import *
+from structured.basic_types import unwrap_annotated, format_type
 
 
 def test_errors() -> None:
@@ -17,8 +18,10 @@ def test_errors() -> None:
 
 class TesteChar:
     def test_static(self) -> None:
-        assert issubclass(char[13], structured.format_type)
-        assert char[13].format == '13s'
+        wrapped = char[13]
+        unwrapped = unwrap_annotated(wrapped)
+        assert issubclass(unwrapped, format_type)
+        assert unwrapped.format == '13s'
 
     def test_dynamic(self) -> None:
         class Base(Structured):


### PR DESCRIPTION
Improves many typehints in Structured classes by replacing types with `Annotated` instances.  For example, `int8 = Annotated[int, _int8]`.

- Deprecates `serialized` until the next breaking release (3.0).  Instead, using `Annotated` is recommended, like `items: list[int8] = Annotated[list[int8], array[..., int8]`.
- Internally, almost all associated types are now `Annotated` instances.
