### PR TITLE
python 3.11 update:

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.9", "3.10"]
+        python-version: ["3.9", "3.10", "3.11"]
         os: [ubuntu-latest, windows-latest, macos-latest]
 
     runs-on: ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -121,7 +121,7 @@ celerybeat.pid
 
 # Environments
 .env
-.venv
+.venv*
 env/
 venv/
 ENV/

--- a/README.md
+++ b/README.md
@@ -292,3 +292,36 @@ assert hasattr(obj.items[0], 'a')
 
 > AssertionError
 ```
+
+
+## Dataclass compatibility
+For the most part, `Structured` should be compatible with the `@dataclass`
+decorator.  To suppress the generated `__init__` method and use `@dataclass`s
+instead, pass `init=False` to the subclassing machinery.
+
+NOTE: The unpacking logic requires your class's `__init__` to accept at least
+all of the unpacked fields in order as arguments, so if you want to write your
+own or use `@dataclass`s, make sure to mark other types as non-initialization
+variables (with `= field(init=False)`).  You can further initialize those
+variables in a `__post_init__` method.
+
+Here's an example of mixing both `structured` types and other types, as well as
+using `@dataclass`s generated `__init__`:
+
+```python
+@dataclass
+class MyStruct(Structured, init=False):
+  a: int8
+  b: int = field(init=False)
+  _: pad[1] = field(init=False)
+  c: uint16
+
+  def __post_init__(self) -> None:
+    self.b = 0
+
+data = struct.pack('bH', 1, 42)
+a = MyStruct.create_unpack(data)
+print(a)
+
+> MyStruct(a=1, c=42)
+```

--- a/structured/complex_types/array_headers.py
+++ b/structured/complex_types/array_headers.py
@@ -35,7 +35,7 @@ class HeaderBase:
         """
 
 
-class StaticHeader(HeaderBase, Structured):
+class StaticHeader(HeaderBase, Structured, init=False):
     """StaticHeader representing a statically sized array."""
 
     # NOTE: HeaderBase first, to get it's __init__
@@ -62,13 +62,13 @@ class StaticHeader(HeaderBase, Structured):
         if count <= 0:
             raise ValueError('count must be positive')
 
-        class _StaticHeader(StaticHeader):
+        class _StaticHeader(StaticHeader, init=False):
             _count: ClassVar[int] = count
 
         return _StaticHeader
 
 
-class DynamicHeader(Generic[TCount], Structured, HeaderBase):
+class DynamicHeader(Generic[TCount], Structured, HeaderBase, init=False):
     """Base for dynamically sized arrays, where the array length is just prior
     to the array data.
     """
@@ -83,13 +83,13 @@ class DynamicHeader(Generic[TCount], Structured, HeaderBase):
 
     @classmethod
     def specialize(cls, count_type: type[TCount]) -> type[DynamicHeader]:
-        class _DynamicHeader(DynamicHeader[count_type]):
+        class _DynamicHeader(DynamicHeader[count_type], init=False):
             pass
 
         return _DynamicHeader
 
 
-class StaticCheckedHeader(Generic[TSize], Structured, HeaderBase):
+class StaticCheckedHeader(Generic[TSize], Structured, HeaderBase, init=False):
     """Statically sized array, with a size check int packed just prior to the
     array data.
     """
@@ -138,7 +138,7 @@ class StaticCheckedHeader(Generic[TSize], Structured, HeaderBase):
         if count <= 0:
             raise ValueError('count must be positive')
 
-        class _StaticCheckedHeader(StaticCheckedHeader[size_type]):
+        class _StaticCheckedHeader(StaticCheckedHeader[size_type], init=False):
             _count: ClassVar[int] = count
 
         return _StaticCheckedHeader

--- a/structured/serializers.py
+++ b/structured/serializers.py
@@ -501,7 +501,6 @@ class CompoundSerializer(Serializer):
         return CompoundSerializer(serializers)
 
     def __add__(self, other: Serializer) -> CompoundSerializer:
-        print('Adding', self, other)
         if isinstance(other, CompoundSerializer):
             to_append = list(other.serializers)
         elif isinstance(other, Serializer):
@@ -527,7 +526,6 @@ class CompoundSerializer(Serializer):
     def __radd__(self, other: Serializer) -> CompoundSerializer:
         # NOTE: CompountSerializer + CompoundSerializer will always call __add__
         # so we only need to optimize for Serializer + CompoundSerializer
-        print('rAdding', other, self)
         if isinstance(other, Serializer):
             serializers = [other]
         else:

--- a/structured/structured.py
+++ b/structured/structured.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+import sys
 
 __all__ = [
     'Structured',
@@ -33,6 +34,7 @@ from .type_checking import (
     isclassvar,
     update_annotations,
     dataclass_transform,
+    Callable,
 )
 from .utils import StructuredAlias, deprecated, warn_deprecated
 
@@ -136,7 +138,34 @@ def get_structured_base(cls: type[Structured]) -> Optional[type[Structured]]:
         return None
 
 
-@dataclass_transform()
+def gen_init(args: dict[str, Any], *, globalsns: dict[str, Any] | None = None, localsns: dict[str, Any] | None = None) -> Callable:
+    """Generates an __init__ method for a class.  `args` should be a mapping of
+    arguments to type annotations to be used in the method definition.
+
+    :param args: Mapping of argument names to argument type annotations, including self.
+    :param globalsns: Any globals needed to be accessed by this method.
+    :param localsns: Any locals needed to be accessed by this method.
+    :return: The generated __init__, without __qualname__set.
+    """
+    if localsns is None:
+        localsns = {}
+    local_vars = ', '.join(localsns.keys())
+    # Inner function text
+    args_txt = ', '.join(f'{name}: {annotation.__name__}' for name, annotation in args.items())
+    def_txt = f' def __init__({args_txt}) -> None:'
+    body_lines = [f'  self.{name} = {name}' for name in args.keys() if name != 'self']
+    body_lines.append('  self.__post_init__()')
+    body_txt = '\n'.join(body_lines)
+    inner_txt = f'{def_txt}\n{body_txt}'
+    # Outer creation function
+    txt = f'def __create_fn__({local_vars}):\n'
+    txt += f'{inner_txt}\n'
+    txt += ' return __init__'
+    namespace = {}
+    exec(txt, globalsns, namespace)
+    return namespace['__create_fn__'](**localsns)
+
+
 class Structured:
     """Base class for classes which can be packed/unpacked using Python's
     struct module."""
@@ -146,31 +175,10 @@ class Structured:
     attrs: ClassVar[tuple[str, ...]] = ()
     byte_order: ClassVar[ByteOrder] = ByteOrder.DEFAULT
 
-    def __init__(self, *args, **kwargs):
-        # TODO: Create the init function on the fly (ala dataclass) so we can
-        # leverage python's error checking for argument names, etc.
-        attrs_values = dict(zip(self.attrs, args))
-        given = len(args)
-        expected = len(self.attrs)
-        if given > expected:
-            raise TypeError(
-                f'{type(self).__qualname__}() takes {expected} positional '
-                f'arguments but {given} were given'
-            )
-        duplicates = set(attrs_values.keys()) & set(kwargs.keys())
-        if duplicates:
-            raise TypeError(
-                f'{duplicates} arguments passed as both positional and keyword.'
-            )
-        attrs_values |= kwargs
-        present = set(attrs_values.keys())
-        if missing := (attr_set := set(self.attrs)) - present:
-            raise TypeError(f'missing arguments {missing}')
-        elif extra := present - attr_set:
-            raise TypeError(f'unknown arguments for {extra}')
-
-        for attr, value in attrs_values.items():
-            setattr(self, attr, value)
+    def __post_init__(self) -> None:
+        """Initialize any instance variables not handled by the Structured
+        unpacking logic.
+        """
 
     def with_byte_order(self, byte_order: ByteOrder) -> Self:
         if byte_order == self.byte_order:
@@ -325,6 +333,7 @@ class Structured:
         cls,
         byte_order: ByteOrder = ByteOrder.DEFAULT,
         byte_order_mode: ByteOrderMode = ByteOrderMode.STRICT,
+        init: bool = True,
         **kwargs,
     ) -> None:
         """Subclassing a Structured type.  We need to compute new values for the
@@ -334,6 +343,8 @@ class Structured:
             Defaults to no byte order marker.
         :param byte_order_mode: Mode to use when resolving conflicts with super
             class's byte order.
+        :param init: Whether to generate an __init__ method for this class (for
+            example, set this to false if you wish to use @dataclass).
         :raises ValueError: If ByteOrder conflicts with the base class and is
             not specified as overridden.
         """
@@ -370,14 +381,29 @@ class Structured:
         # Analyze the class
         typehints = get_type_hints(cls, include_extras=True)
         applicable_typehints = filter_typehints(typehints, classdict)
+        # Which variables show up in the __init__
+        # Need to ensure 'self' shows up first
+        typehints = get_type_hints(cls)
+        init_vars = {'self': Self}
+        init_vars |= {attr: typehints.get(attr, Any)
+                      for attr in applicable_typehints
+                      if not ispad(applicable_typehints[attr])
+        }
+        # But also don't want 'self' to show up in attrs
+        attrs = tuple(init_vars.keys())[1:]
         serializer = sum(
             applicable_typehints.values(), NullSerializer()
         ).with_byte_order(byte_order)
-        attrs = tuple(
-            attr
-            for attr, attr_type in applicable_typehints.items()
-            if not ispad(attr_type)
-        )
+        if init:
+            # Generate an init method
+            if cls.__module__ in sys.modules:
+                globals = sys.modules[cls.__module__].__dict__
+            else:
+                globals = {}
+
+            init_fn = gen_init(init_vars, globalsns=globals)
+            init_fn.__qualname__ = f'{cls.__qualname__}.__init__'
+            cls.__init__ = init_fn
         # And set the updated class attributes
         cls.serializer = serializer
         cls.attrs = attrs

--- a/structured/structured.py
+++ b/structured/structured.py
@@ -32,6 +32,7 @@ from .type_checking import (
     get_type_hints,
     isclassvar,
     update_annotations,
+    dataclass_transform,
 )
 from .utils import StructuredAlias, deprecated, warn_deprecated
 
@@ -135,6 +136,7 @@ def get_structured_base(cls: type[Structured]) -> Optional[type[Structured]]:
         return None
 
 
+@dataclass_transform()
 class Structured:
     """Base class for classes which can be packed/unpacked using Python's
     struct module."""

--- a/structured/type_checking.py
+++ b/structured/type_checking.py
@@ -25,9 +25,9 @@ else:
     from typing import ParamSpec, TypeAlias, TypeGuard
 
 if sys.version_info < (3, 11):
-    from typing_extensions import Self
+    from typing_extensions import Self, dataclass_transform
 else:
-    from typing import Self
+    from typing import Self, dataclass_transform
 
 
 _T = TypeVar('_T')


### PR DESCRIPTION
- partial support for dataclass-like behavior with typecheckers
  * still need to investigate if it's possible to *NOT* have all attributes picked up for the `__init__` as far as the IDEs are concerned.  In particular, `pad` variables would especially be nice to be autodetected as `init=False`.
  * Might need to define a custom `dataclasses.Field`-like class and pass that into the `dataclass_transform` method.
- Run tests on python 3.11

Still needs:
- Docs updates
- `dataclasses.Field`-like investigation.