### PR TITLE
25 - no Formatted

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.coverage.run]
 branch = true
 source = ['structured']
+omit = ['structured/type_checking.py']
 
 [tool.coverage.report]
 show_missing = true

--- a/structured/__init__.py
+++ b/structured/__init__.py
@@ -1,5 +1,5 @@
 __author__ = 'lojack5'
-__version__ = '2.0.2'
+__version__ = '3.0.0'
 
 from .base_types import *
 from .basic_types import *

--- a/structured/complex_types/strings.py
+++ b/structured/complex_types/strings.py
@@ -59,6 +59,7 @@ class char(str, requires_indexing):
                       type[Union[uint8, uint16, uint32, uint64]],
                       type[NET]]
     """
+
     def __class_getitem__(cls, args) -> type[bytes]:
         """Create a char specialization."""
         if not isinstance(args, tuple):

--- a/structured/complex_types/strings.py
+++ b/structured/complex_types/strings.py
@@ -17,7 +17,7 @@ from functools import cache, partial
 
 from ..base_types import ByteOrder, requires_indexing
 from ..basic_types import _SizeTypes, _TSize, unwrap_annotated
-from ..serializers import Serializer, StructSerializer, future_requires_indexing
+from ..serializers import Serializer, StructSerializer
 from ..type_checking import (
     Annotated,
     Any,
@@ -44,7 +44,7 @@ class NET:
 _single_char = StructSerializer('s')
 
 
-class char(str, future_requires_indexing):
+class char(str, requires_indexing):
     """A bytestring, with three ways of denoting length. If size is an integer,
     it is a static size.  If a uint* type is specified, it is prefixed with
     a packed value of that type which holds the length.  If the NET type is
@@ -59,10 +59,6 @@ class char(str, future_requires_indexing):
                       type[Union[uint8, uint16, uint32, uint64]],
                       type[NET]]
     """
-
-    # TODO: version 3.* replace future_requires_indexing with requires_indexing
-    serializer: ClassVar[StructSerializer] = _single_char
-
     def __class_getitem__(cls, args) -> type[bytes]:
         """Create a char specialization."""
         if not isinstance(args, tuple):

--- a/structured/serializers.py
+++ b/structured/serializers.py
@@ -325,28 +325,6 @@ class StructSerializer(struct.Struct, Serializer):
         return StructSerializer(fmt, self.num_values * other, byte_order)
 
 
-class future_requires_indexing:
-    """Temporary marker base class for classes that will become based on
-    ``requires_indexing`` in the future (pad, pascal, char).
-    """
-
-    serializer: ClassVar[Serializer]
-
-
-class counted(future_requires_indexing):
-    """Base class for simple StructSerializers which have an optional count
-    argument before the format specifier.  Examples of this are `char[10]` and
-    `pad[13]`.
-    """
-
-    serializer: ClassVar[StructSerializer]
-    value_type: ClassVar[type]
-
-    @classmethod
-    def __class_getitem__(cls, count: int) -> type[Self]:
-        return Annotated[cls.value_type, cls.serializer * count]  # type: ignore
-
-
 def _apply_actions(unpacker):
     @wraps(unpacker)
     def wrapped(self, *args, **kwargs):

--- a/structured/serializers.py
+++ b/structured/serializers.py
@@ -37,8 +37,6 @@ from typing import TypeVar, overload
 
 from .base_types import ByteOrder
 from .type_checking import (
-    _T,
-    Annotated,
     Any,
     BinaryIO,
     Callable,
@@ -46,11 +44,12 @@ from .type_checking import (
     Iterable,
     ReadableBuffer,
     Self,
+    T,
     WritableBuffer,
 )
 
 
-def noop_action(x: _T) -> _T:
+def noop_action(x: T) -> T:
     """A noop for StructActionSerializers where no additional wrapping is
     needed.
     """

--- a/structured/structured.py
+++ b/structured/structured.py
@@ -11,11 +11,7 @@ from functools import cache, reduce
 
 from .base_types import ByteOrder, ByteOrderMode, requires_indexing
 from .basic_types import ispad, unwrap_annotated
-from .serializers import (
-    NullSerializer,
-    Serializer,
-    StructSerializer,
-)
+from .serializers import NullSerializer, Serializer, StructSerializer
 from .type_checking import (
     Any,
     BinaryIO,
@@ -315,7 +311,6 @@ class Structured:
                     'If this is intentional, use `byte_order_mode=OVERRIDE`.'
                 )
         # Evaluta any generics in base class
-        classdict = cls.__dict__
         if base:
             orig_bases = getattr(cls, '__orig_bases__', ())
             base_to_origbase = {
@@ -325,9 +320,7 @@ class Structured:
             }
             orig_base = base_to_origbase.get(base, None)
             if orig_base:
-                annotations = base._get_specialization_hints(
-                    *get_args(orig_base)
-                )
+                annotations = base._get_specialization_hints(*get_args(orig_base))
                 update_annotations(cls, annotations)
         # Analyze the class
         typehints = get_type_hints(cls, include_extras=True)

--- a/structured/structured.py
+++ b/structured/structured.py
@@ -4,7 +4,6 @@ import sys
 
 __all__ = [
     'Structured',
-    'serialized',
 ]
 
 import operator
@@ -16,7 +15,6 @@ from .serializers import (
     NullSerializer,
     Serializer,
     StructSerializer,
-    future_requires_indexing,
 )
 from .type_checking import (
     Any,
@@ -36,7 +34,7 @@ from .type_checking import (
     isclassvar,
     update_annotations,
 )
-from .utils import StructuredAlias, deprecated, warn_deprecated, attrgetter
+from .utils import StructuredAlias, attrgetter
 
 
 def validate_typehint(attr_type: type) -> TypeGuard[Serializer]:
@@ -49,68 +47,29 @@ def validate_typehint(attr_type: type) -> TypeGuard[Serializer]:
     """
     if isclassvar(attr_type):
         return False
-    if isinstance(attr_type, type):
-        if issubclass(attr_type, requires_indexing):
-            raise TypeError(f'{attr_type.__qualname__} must be specialized')
-        if issubclass(attr_type, (Serializer, Structured)):
-            return True
-        if issubclass(attr_type, future_requires_indexing):
-            warn_deprecated(
-                attr_type,
-                '2.2',
-                '3.0',
-                issue=0,
-                use_instead=f'Use explicit length: {attr_type.__name__}[1]',
-            )
-            return True
-    elif isinstance(attr_type, Serializer):
+    if isinstance(attr_type, type) and issubclass(attr_type, requires_indexing):
+        raise TypeError(f'{attr_type.__qualname__} must be specialized')
+    if isinstance(attr_type, Serializer):
         return True
     return False
 
 
-@deprecated('2.1.0', '3.0', issue=5, use_instead='Annotated[unpacked_type, kind]')
-def serialized(kind: Any) -> Any:
-    """Type erasure for class definitions, allowing for linters to pick up the
-    correct final type.  For example:
-
-    class MyStruct(Structured):
-        items: list[int] = serialized(array[4, int32])
-    """
-    return kind
-
-
 def filter_typehints(
     typehints: dict[str, Any],
-    classdict: dict[str, Any],
 ) -> dict[str, Serializer]:
     """Filters a typehints dictionary of a class for only the types which
     Structured uses to generate serializers.
 
     :param typehints: A class's typehints dictionary.  NOTE: This needs to be
         obtained via `get_type_hints(..., include_extras=True)`.
-    :param classdict: The class's dictionary, used for the deprecated optional
-        syntax of using `serialized`.
     :return: A filtered dictionary containing only attributes with types used
         by Structured.
-    :rtype: dict[str, type[_Annotation]]
     """
-    filtered = {
+    return {
         attr: unwrapped
         for attr, attr_type in typehints.items()
         if validate_typehint((unwrapped := unwrap_annotated(attr_type)))
     }
-    for attr, attr_type in tuple(classdict.items()):
-        if validate_typehint((unwrapped := unwrap_annotated(attr_type))):
-            filtered[attr] = unwrapped
-            # del classdict[attr]
-    # TODO: version 3.* remove this backwards compatibility for pad, char, pascal
-    for attr in filtered:
-        attr_type = filtered[attr]
-        if isinstance(attr_type, type) and issubclass(
-            attr_type, future_requires_indexing
-        ):
-            filtered[attr] = attr_type.serializer
-    return filtered
 
 
 def get_structured_base(cls: type[Structured]) -> Optional[type[Structured]]:
@@ -122,11 +81,9 @@ def get_structured_base(cls: type[Structured]) -> Optional[type[Structured]]:
         Structured class itself, or None if no such base class exists.
     """
     bases = tuple(
-        (
-            base
-            for base in cls.__bases__
-            if issubclass(base, Structured) and base is not Structured
-        )
+        base
+        for base in cls.__bases__
+        if issubclass(base, Structured) and base is not Structured
     )
     if len(bases) > 1:
         raise TypeError(
@@ -305,15 +262,8 @@ class Structured:
                 'If they are meant to be serailized, make sure to annotate '
                 'them appropriately.'
             )
-        # TODO: optimization possible?  Most of the calls here are cached
-        # already, so the most expensive part is the get_type_hints part.  But
-        # this method is cached too, so just go as is?
-        items = get_type_hints(cls, include_extras=True).items()
-        hints = {
-            attr: unwrap_annotated(attr_type)
-            for attr, attr_type in items
-            if attr in attrs
-        }
+        hints = filter_typehints(get_type_hints(cls, include_extras=True))
+        hints = {attr: hint for attr, hint in hints.items() if attr in attrs}
         serializer = sum(hints.values(), NullSerializer()).with_byte_order(
             cls.byte_order
         )
@@ -375,15 +325,13 @@ class Structured:
             }
             orig_base = base_to_origbase.get(base, None)
             if orig_base:
-                annotations, clsdict = base._get_specialization_hints(
+                annotations = base._get_specialization_hints(
                     *get_args(orig_base)
                 )
                 update_annotations(cls, annotations)
-                # NOTE: cls.__dict__ is a mappingproxy
-                classdict = dict(classdict) | clsdict
         # Analyze the class
         typehints = get_type_hints(cls, include_extras=True)
-        applicable_typehints = filter_typehints(typehints, classdict)
+        applicable_typehints = filter_typehints(typehints)
         # Which variables show up in the __init__
         # Need to ensure 'self' shows up first
         typehints = get_type_hints(cls)
@@ -418,8 +366,8 @@ class Structured:
     def _get_specialization_hints(
         cls,
         *args,
-    ) -> tuple[dict[str, Any], dict[str, Any]]:
-        """Get needed updates to __annotations__ and __dict__ if this class were
+    ) -> dict[str, Any]:
+        """Get needed updates to __annotations__ and if this class were
         to be specialized with `args`,
         """
         supers: dict[type[Structured], Any] = {}
@@ -434,7 +382,6 @@ class Structured:
             raise TypeError(f'{cls.__name__} is not a Generic')
         # First handle the direct base class
         annotations = {}
-        classdict = {}
         cls_annotations = get_annotations(cls)
         for attr, attr_type in get_type_hints(cls, include_extras=True).items():
             if attr in cls_annotations:
@@ -444,19 +391,11 @@ class Structured:
                     annotations[attr] = remapped_type
                 elif isinstance(unwrapped, StructuredAlias):
                     annotations[attr] = unwrapped.resolve(tvar_map)
-        for attr, attr_val in cls.__dict__.items():
-            unwrapped = unwrap_annotated(attr_val)
-            if isinstance(unwrapped, StructuredAlias):
-                classdict[attr] = unwrapped.resolve(tvar_map)
         # Now any classes higher in the chain
         all_annotations = [annotations]
-        all_classdict = [classdict]
         for base, alias in supers.items():
             args = get_args(alias)
             args = (tvar_map.get(arg, arg) for arg in args)
-            super_annotations, super_classdict = base._get_specialization_hints(*args)
+            super_annotations = base._get_specialization_hints(*args)
             all_annotations.append(super_annotations)
-            all_classdict.append(super_classdict)
-        final_annotations = reduce(operator.or_, reversed(all_annotations))
-        final_classdict = reduce(operator.or_, reversed(all_classdict))
-        return final_annotations, final_classdict
+        return reduce(operator.or_, reversed(all_annotations))

--- a/structured/type_checking.py
+++ b/structured/type_checking.py
@@ -32,7 +32,8 @@ else:
     from typing import Self, dataclass_transform
 
 
-_T = TypeVar('_T')
+S = TypeVar('S')
+T = TypeVar('T')
 
 
 def update_annotations(cls: type, annotations: dict[str, Any]) -> None:

--- a/structured/type_checking.py
+++ b/structured/type_checking.py
@@ -1,3 +1,5 @@
+# pragma: no cover
+
 import sys
 import typing
 from typing import (

--- a/structured/utils.py
+++ b/structured/utils.py
@@ -1,11 +1,11 @@
 """
 Various utility methods.
 """
+import operator
 import warnings
 from functools import wraps
-import operator
 
-from .type_checking import _T, Any, Callable, NoReturn, Optional, ParamSpec, TypeVar
+from .type_checking import Any, Callable, NoReturn, Optional, ParamSpec, T, TypeVar
 
 
 def attrgetter(*attr_names: str) -> Callable[[Any], tuple[Any, ...]]:
@@ -28,7 +28,7 @@ def __error_getitem__(cls: type, _key: Any) -> NoReturn:
     raise TypeError(f'{cls.__qualname__} is already specialized.')
 
 
-def specialized(base_cls: type, *args: Any) -> Callable[[type[_T]], type[_T]]:
+def specialized(base_cls: type, *args: Any) -> Callable[[type[T]], type[T]]:
     """Marks a class as already specialized, overriding the class' indexing
     method with one that raises a helpful error.  Also fixes up the class'
     qualname to be a more readable name.
@@ -37,7 +37,7 @@ def specialized(base_cls: type, *args: Any) -> Callable[[type[_T]], type[_T]]:
     :return: The class with described modifications.
     """
 
-    def wrapper(cls: type[_T]) -> type[_T]:
+    def wrapper(cls: type[T]) -> type[T]:
         setattr(cls, '__class_getitem__', __error_getitem__)
         qualname = ', '.join((getattr(k, '__qualname__', f'{k}') for k in args))
         name = ', '.join((getattr(k, '__name__', f'{k}') for k in args))

--- a/tests/test_arrays.py
+++ b/tests/test_arrays.py
@@ -103,7 +103,7 @@ def test_static_format():
 
 
 def test_static_format_action():
-    class WrappedInt(Formatted):
+    class WrappedInt:
         def __init__(self, wrapped: int):
             self._wrapped = wrapped
 
@@ -114,11 +114,12 @@ def test_static_format_action():
             if isinstance(other, type(self)):
                 return self._wrapped == other._wrapped
             return NotImplemented
+    WrappedInt8 = Annotated[WrappedInt, SerializeAs(int8)]
 
     class StaticAction(Structured):
-        a: array[Header[3], WrappedInt[int8]]
+        a: array[Header[3], WrappedInt8]
 
-    target_obj = StaticAction(list(map(WrappedInt[int8], (1 ,2, 3))))
+    target_obj = StaticAction(list(map(WrappedInt, (1 ,2, 3))))
 
     st = struct.Struct('3b')
     target_data = st.pack(1, 2, 3)

--- a/tests/test_base_types.py
+++ b/tests/test_base_types.py
@@ -84,8 +84,7 @@ class TestCustomType:
                     return self._wrapped == other._wrapped
                 else:
                     return self._wrapped == other
-        serialized = StructActionSerializer('b', actions=(MutableType.from_int, ))
-        MutableType8 = Annotated[MutableType, SerializeAs(serialized)]
+        MutableType8 = Annotated[MutableType, SerializeAs(int8).with_factory(MutableType.from_int)]
 
         class Base(Structured):
             a: MutableType8

--- a/tests/test_base_types.py
+++ b/tests/test_base_types.py
@@ -1,6 +1,8 @@
 import io
 import struct
 
+from typing import TypeAlias, Annotated
+
 import pytest
 
 from structured import *
@@ -23,9 +25,9 @@ def test_counted() -> None:
         pad[0]
 
 
-class TestFormatted:
+class TestCustomType:
     def test_subclassing_any(self) -> None:
-        class MutableType(Formatted):
+        class MutableType:
             def __init__(self, value: int):
                 self._value = value
 
@@ -45,15 +47,15 @@ class TestFormatted:
                 else:
                     return self._value == other
 
-        serializer = unwrap_annotated(MutableType[int16])
+        serializer = unwrap_annotated(Annotated[MutableType, SerializeAs(int16)])
         assert isinstance(serializer, StructActionSerializer)
         assert serializer.format == 'h'
         assert serializer.actions == (MutableType,)
 
         class Base(Structured):
-            a: MutableType[int16]
-            b: MutableType[uint32]
-        target_obj = Base(MutableType[int16](11), MutableType[uint32](42))
+            a: Annotated[MutableType, SerializeAs(int16)]
+            b: Annotated[MutableType, SerializeAs(uint32)]
+        target_obj = Base(MutableType(11), MutableType(42))
 
         target_data = Base.serializer.pack(11, 42)
 
@@ -64,7 +66,7 @@ class TestFormatted:
         assert b.a == 11
 
     def test_custom_action(self) -> None:
-        class MutableType(Formatted):
+        class MutableType:
             _wrapped: int
 
             def __init__(self, not_an_int, value: int):
@@ -82,17 +84,18 @@ class TestFormatted:
                     return self._wrapped == other._wrapped
                 else:
                     return self._wrapped == other
+        serialized = StructActionSerializer('b', actions=(MutableType.from_int, ))
+        MutableType8 = Annotated[MutableType, SerializeAs(serialized)]
 
-        MutableType.unpack_action = MutableType.from_int
         class Base(Structured):
-            a: MutableType[int8]
+            a: MutableType8
             b: int8
         assert isinstance(Base.serializer, StructActionSerializer)
         assert Base.serializer.actions == (MutableType.from_int, noop_action)
         assert Base.serializer.format == '2b'
         assert Base.serializer.num_values == 2
 
-        target_obj = Base(MutableType[int8](None, 42), 10)
+        target_obj = Base(MutableType(None, 42), 10)
         target_data = struct.pack('2b', 42, 10)
 
         assert target_obj.pack() == target_data
@@ -109,30 +112,12 @@ class TestFormatted:
             stream.seek(0)
             assert Base.create_unpack_read(stream) == target_obj
 
-    def test_subclassing_specialized(self) -> None:
-        class MutableType(Formatted):
-            _types = frozenset({int8, int16})
-        serializer = unwrap_annotated(MutableType[int8])
-        assert isinstance(serializer, StructActionSerializer)
-        assert serializer.format == 'b'
-        assert serializer.actions == (MutableType, )
-
     def test_errors(self) -> None:
-        class Error1(Formatted):
-            # Purposfully setting an incorrect type for _types, hence the ignore
-            _types = frozenset({int})   # type: ignore
         with pytest.raises(TypeError):
-            # Errors due to not having `int8` in `_types`
-            Error1[int8]
+            # Must serialize as a StructSerializer with 1 value
+            SerializeAs(pad[1])
         with pytest.raises(TypeError):
-            # Errors due to `int` not being a `format_type`
-            Error1[int]
-
-        class Error2(Formatted):
-            pass
+            SerializeAs(StructSerializer('2b', 2))
         with pytest.raises(TypeError):
-            Error2[int]
-
-        Error3 = Error2[int8]
-        with pytest.raises(TypeError):
-            Error3[int8]
+            # Not a struct serializer
+            SerializeAs(array)

--- a/tests/test_base_types.py
+++ b/tests/test_base_types.py
@@ -1,7 +1,7 @@
 import io
 import struct
 
-from typing import TypeAlias, Annotated
+from typing import Annotated
 
 import pytest
 

--- a/tests/test_structured.py
+++ b/tests/test_structured.py
@@ -149,6 +149,17 @@ class TestStructured:
         assert isinstance(Derived2.serializer, struct.Struct)
         assert Derived2.serializer.format == ByteOrder.LE.value + '2b'
 
+    def test_with_byte_order(self) -> None:
+        class Base(Structured):
+            a: uint16
+        objLE = Base(0xF0).with_byte_order(ByteOrder.LE)
+        objBE = Base(0xF0).with_byte_order(ByteOrder.BE)
+        target_le_data = struct.pack(f'{ByteOrder.LE.value}H', 0xF0)
+        target_be_data = struct.pack(f'{ByteOrder.BE.value}H', 0xF0)
+        assert target_le_data != target_be_data
+        assert objLE.pack() == target_le_data
+        assert objBE.pack() == target_be_data
+
     def test_unpack_read(self) -> None:
         class Base(Structured):
             a: int8


### PR DESCRIPTION
- Removes deprecated functionality from < 3.0
- Replaces `Formatted` with a bit simpler `SerializedAs` + `typing.Annotated`.

Closes #25 