### PR TITLE
bringing back the metaclass

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Notes:
  1. These type must be indexed to specify their length.  For a single byte `char` for example (`'s'`), use `char[1]`.
  2. The 16-bit float type is not supported on all platforms.
  3. `struct` treats `bool` as an `int`, so this is implemented as an `int`.  Packing and unpacking works that same as with `struct`.
- 4. Pad variables are skipped and not actually assigned when unpacking, nor used when packing.
+ 4. Pad variables are skipped and not actually assigned when unpacking, nor used when packing.  There is a special metaclass hook to allow you to name all of your pad variables `_`, and they still **all** count towards the final format specifier.  If you want to be able to override their typehint in subclasses, choose a name other than `_`.
 
 You can also specify byte order packing/unpacking rules, by passing a `ByteOrder` to the `Structured` class on class creation.  For example:
 

--- a/structured/type_checking.py
+++ b/structured/type_checking.py
@@ -11,6 +11,7 @@ from typing import (
     Container,
     Generic,
     Iterable,
+    Iterator,
     NewType,
     NoReturn,
     Optional,

--- a/tests/test_structured.py
+++ b/tests/test_structured.py
@@ -9,6 +9,19 @@ from structured import *
 
 
 class TestStructured:
+    def test_multiple_pad(self) -> None:
+        class Base(Structured):
+            _ : pad[1]
+            _ : pad[3]
+            _ : pad[4]
+        assert isinstance(Base.serializer, struct.Struct)
+        assert Base.serializer.format == '8x'
+
+        class Derived(Base):
+            _ : pad[2]
+        assert isinstance(Derived.serializer, struct.Struct)
+        assert Derived.serializer.format == '10x'
+
     def test_init__(self) -> None:
         class Base(Structured):
             a: int8


### PR DESCRIPTION
With serialization information all in the type-hints now, it was pretty simple to implement multiple pad variables all named `_` counting towards the final format specifier.

Closes #12 