### PR TITLE
Switch to unions configured via typing.Annotated

### DIFF
--- a/structured/base_types.py
+++ b/structured/base_types.py
@@ -36,7 +36,7 @@ class requires_indexing:
     """
 
     @staticmethod
-    def _transform(unwrapped: Any, actual: Any, cls: type, name: str) -> Any:
+    def _transform(unwrapped: Any, actual: Any) -> Any:
         for a in (unwrapped, actual):
             if safe_issubclass(unwrapped, requires_indexing):
                 raise TypeError(f'{a.__name__} must be indexed.')

--- a/structured/hint_types/serialize_as.py
+++ b/structured/hint_types/serialize_as.py
@@ -32,7 +32,7 @@ class SerializeAs(Generic[S, T]):
         return type(self)(StructActionSerializer(st.format, actions=(action,)))
 
     @staticmethod
-    def _transform(unwrapped: Any, actual: Any, cls: type, name: str) -> Any:
+    def _transform(unwrapped: Any, actual: Any) -> Any:
         if isinstance(unwrapped, SerializeAs):
             st = unwrapped.serializer
             if isinstance(st, StructActionSerializer):

--- a/structured/serializers/structured.py
+++ b/structured/serializers/structured.py
@@ -61,7 +61,7 @@ class StructuredSerializer(Generic[TStructured], Serializer[TStructured]):
         return (self.obj_type.create_unpack_read(readable),)
 
     @staticmethod
-    def _transform(unwrapped: Any, actual: Any, cls: type, name: str) -> Any:
+    def _transform(unwrapped: Any, actual: Any) -> Any:
         from ..structured import Structured
 
         for x in (actual, unwrapped):

--- a/structured/structured.py
+++ b/structured/structured.py
@@ -47,7 +47,7 @@ def ispad(annotation: Any) -> bool:
     return False
 
 
-def transform_typehint(hint: Any, cls: type, name: str) -> Union[Serializer, None]:
+def transform_typehint(hint: Any) -> Union[Serializer, None]:
     """Read in a typehint, and apply any transformations that need to be done
     to it.  If the result is a hint Structured is concerned about, return it,
     otherwise returns None.
@@ -56,8 +56,7 @@ def transform_typehint(hint: Any, cls: type, name: str) -> Union[Serializer, Non
     """
     if isclassvar(hint):
         return None
-    extracter = annotated(Serializer)
-    unwrapped = extracter.with_check(isunion).extract(hint, cls=cls, name=name)
+    unwrapped = annotated(Serializer).with_check(isunion).extract(hint)
     if isinstance(unwrapped, Serializer):
         return unwrapped
     return None
@@ -78,7 +77,7 @@ def filter_typehints(
     return {
         attr: transformed
         for attr, hint in typehints.items()
-        if (transformed := transform_typehint(hint, cls, attr)) is not None
+        if (transformed := transform_typehint(hint)) is not None
     }
 
 

--- a/structured/type_checking.py
+++ b/structured/type_checking.py
@@ -131,7 +131,7 @@ class _annotated(Generic[Unpack[Ts]]):
 
     @classmethod
     def register_transform(
-        cls, transformer: Callable[[Any, Any, type, str], Union[Unpack[Ts]]]
+        cls, transformer: Callable[[Any, Any], Union[Unpack[Ts]]]
     ) -> None:
         cls._transforms.append(transformer)
 
@@ -155,11 +155,12 @@ class _annotated(Generic[Unpack[Ts]]):
 
     def _transform_and_check(self, unwrapped, actual, cls, name):
         for xform in type(self)._transforms:
-            unwrapped = xform(unwrapped, actual, cls, name)
+            unwrapped = xform(unwrapped, actual)
         if self._custom_check:
-            if self._custom_check(unwrapped):
-                return unwrapped
-            if self._custom_check(actual):
+            if unwrapped is not None:
+                if self._custom_check(unwrapped):
+                    return unwrapped
+            elif self._custom_check(actual):
                 return actual
         for x in (unwrapped, actual):
             if isinstance(x, type):

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -1,6 +1,6 @@
 """Serializer tests which aren't covered by the tests of full Structured
 classes"""
-from typing import Union
+from typing import Union, Annotated
 
 import pytest
 
@@ -90,7 +90,7 @@ class TestCompoundSerializer:
     class Base1(Structured):
         # Force a compound serializer
         a: int8
-        b: Union[int8, char[1]] = config(LookbackDecider(lambda x: 0, {0: int8}))
+        b: Annotated[Union[int8, char[1]], LookbackDecider(lambda x: 0, {0: int8})]
 
     def test_add(self) -> None:
         # The rest are tested by Structured class creation

--- a/tests/test_unions.py
+++ b/tests/test_unions.py
@@ -2,7 +2,7 @@ import sys
 import struct
 from operator import attrgetter
 import io
-from typing import Union
+from typing import Union, Annotated
 
 import pytest
 
@@ -36,7 +36,7 @@ def test_errors() -> None:
 
 def test_lookback() -> None:
     class Base(Structured):
-        a: Union[int8, char[1]] = config(LookbackDecider(lambda x: 0, {0: int8}, int8))
+        a: Annotated[Union[int8, char[1]], LookbackDecider(lambda x: 0, {0: int8}, int8)]
 
     assert isinstance(Base.serializer, LookbackDecider)
 
@@ -69,7 +69,7 @@ def test_lookahead() -> None:
         value: float32
 
     class Outer(Structured):
-        record: Union[IntRecord, FloatRecord] = config(LookaheadDecider(char[4], attrgetter('record.sig'), {b'IINT': IntRecord, b'FLOA': FloatRecord}, None))
+        record: Annotated[Union[IntRecord, FloatRecord], LookaheadDecider(char[4], attrgetter('record.sig'), {b'IINT': IntRecord, b'FLOA': FloatRecord}, None)]
 
     int_data = struct.pack('4sI', b'IINT', 42)
     float_data = struct.pack('4sf', b'FLOA', 1.125) # NOTE: exact float in binary
@@ -96,7 +96,7 @@ def test_lookahead() -> None:
 @pytest.mark.skipif(sys.version_info < (3, 10), reason='requires Python 3.10 or higher')
 def test_union_syntax() -> None:
     class Base(Structured):
-        a: int8 | char[4] = config(LookbackDecider(lambda x: 0, {0: int8}, int8))
+        a: Annotated[int8 | char[4], LookbackDecider(lambda x: 0, {0: int8}, int8)]
 
     assert isinstance(Base.serializer, AUnion)
 
@@ -104,7 +104,7 @@ def test_union_syntax() -> None:
 def test_compound_serializer() -> None:
     class Base(Structured):
         a_type: uint8
-        a: Union[uint32, float32, char[4]] = config(LookbackDecider(attrgetter('a_type'), {0: uint32, 1: float32}, char[4]))
+        a: Annotated[Union[uint32, float32, char[4]], LookbackDecider(attrgetter('a_type'), {0: uint32, 1: float32}, char[4])]
 
     assert Base.attrs == ('a_type', 'a')
     assert isinstance(Base.serializer, CompoundSerializer)


### PR DESCRIPTION
Decided to do it, Unions are configured via `typing.Annotated`.

Closes #24 