### PR TITLE
Generics improvements:

### DIFF
--- a/structured/__init__.py
+++ b/structured/__init__.py
@@ -1,5 +1,5 @@
 __author__ = 'lojack5'
-__version__ = '3.0.0'
+__version__ = '3.0.1'
 
 from .base_types import *
 from .hint_types import *


### PR DESCRIPTION
automatically sub-class Structured generics in cases where it won't interfere with how `typing.Generic` normally behaves. So this is limited to when used as a type-hint within a non-generic `Structured` class.  This is nested to arbitrary levels, so only the outer-most `Structured` class needs to be non-generic.

Otherwise, manual sub-classing will still work to get the concrete implementation of the class.

Closes #8 