### PR TITLE
Fix for `StructActionSerializer` losing their actions

### DIFF
--- a/structured/serializers/structs.py
+++ b/structured/serializers/structs.py
@@ -122,7 +122,7 @@ class StructSerializer(Generic[Unpack[Ts]], struct.Struct, Serializer[Unpack[Ts]
         if old_byte_order is byte_order:
             return self
         else:
-            return StructSerializer(fmt, byte_order)
+            return type(self)(fmt, byte_order)
 
     def unpack(self, buffer: ReadableBuffer) -> tuple[Unpack[Ts]]:
         return super().unpack(buffer[: self.size])  # type: ignore

--- a/tests/test_base_types.py
+++ b/tests/test_base_types.py
@@ -49,18 +49,19 @@ class TestCustomType:
                 else:
                     return self._value == other
 
-        class Base(Structured):
-            a: Annotated[MutableType, SerializeAs(int16)]
-            b: Annotated[MutableType, SerializeAs(uint32)]
-        assert isinstance(Base.serializer, StructActionSerializer)
-        assert Base.serializer.actions == (MutableType, MutableType)
-        target_obj = Base(MutableType(11), MutableType(42))
-        target_data = Base.serializer.pack(11, 42)
+        for bo in ByteOrder:
+            class Base(Structured, byte_order=bo):
+                a: Annotated[MutableType, SerializeAs(int16)]
+                b: Annotated[MutableType, SerializeAs(uint32)]
+            assert isinstance(Base.serializer, StructActionSerializer)
+            assert Base.serializer.actions == (MutableType, MutableType)
+            target_obj = Base(MutableType(11), MutableType(42))
+            target_data = Base.serializer.pack(11, 42)
 
-        standard_tests(target_obj, target_data)
+            standard_tests(target_obj, target_data)
 
-        b = Base.create_unpack(target_data)
-        assert isinstance(b.a, MutableType)
+            b = Base.create_unpack(target_data)
+            assert isinstance(b.a, MutableType)
 
 
     def test_custom_action(self) -> None:


### PR DESCRIPTION
When `.with_byte_order` is called `StructSerializer`s were made rather than `StructActionSerializer`s.

Closes #50 