### PR TITLE
45 consume all

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,9 @@ For unpacking bytes other than with a fixed length, you have a few more options 
   discarded). For packing, the `bytes` will be written, and a terminator will be written at the end
   if not already written.  The usual case for this is NULL-terminated byte-strings, so a quick alias
   for that is provided: `null_char`.
+- `char[math.inf]`: This indicates that every remaining byte in the input stream should be unpacked
+  (read to the end). Note that this means no other serialized types can occur after this item.
+- `unicode[math.inf]`: Like `char[math.inf]`, but the bytes are then decoded into a string.
 
 
 ### `unicode`

--- a/structured/hint_types/arrays.py
+++ b/structured/hint_types/arrays.py
@@ -20,7 +20,7 @@ from ..serializers import (
     StaticStructArraySerializer,
     StructSerializer,
 )
-from ..type_checking import Annotated, Generic, S, Self, T, TypeVar, annotated, Optional
+from ..type_checking import Annotated, Generic, Optional, S, Self, T, TypeVar, annotated
 from ..utils import StructuredAlias
 from .basic_types import _SizeTypes
 

--- a/structured/hint_types/arrays.py
+++ b/structured/hint_types/arrays.py
@@ -98,6 +98,8 @@ class array(Generic[S, T], list[T], requires_indexing):
         item_serializer = annotated.transform(item_type)
         if not isinstance(item_serializer, Serializer):
             raise TypeError(f'invalid array item type: {item_type!r}')
+        elif item_serializer.is_final():
+            raise TypeError(f'invalid array item type: {item_type!r}. Final serializers cannot be used.')
         # All good, check for specializations for struct.Struct unpackable
         if (
             isinstance(item_serializer, StructSerializer)

--- a/structured/hint_types/arrays.py
+++ b/structured/hint_types/arrays.py
@@ -20,7 +20,7 @@ from ..serializers import (
     StaticStructArraySerializer,
     StructSerializer,
 )
-from ..type_checking import Annotated, Generic, S, Self, T, TypeVar, annotated
+from ..type_checking import Annotated, Generic, S, Self, T, TypeVar, annotated, Optional
 from ..utils import StructuredAlias
 from .basic_types import _SizeTypes
 
@@ -31,7 +31,7 @@ class Header:
     def __init__(
         self,
         count: int | StructSerializer[int],
-        data_size: StructSerializer[int] | None,
+        data_size: Optional[StructSerializer[int]],
     ) -> None:
         self.count = count
         self.data_size = data_size

--- a/structured/hint_types/arrays.py
+++ b/structured/hint_types/arrays.py
@@ -99,7 +99,10 @@ class array(Generic[S, T], list[T], requires_indexing):
         if not isinstance(item_serializer, Serializer):
             raise TypeError(f'invalid array item type: {item_type!r}')
         elif item_serializer.is_final():
-            raise TypeError(f'invalid array item type: {item_type!r}. Final serializers cannot be used.')
+            raise TypeError(
+                f'invalid array item type: {item_type!r} contains final '
+                f'{item_serializer.get_final()}. Final serializers cannot be used.'
+            )
         # All good, check for specializations for struct.Struct unpackable
         if (
             isinstance(item_serializer, StructSerializer)

--- a/structured/hint_types/condition.py
+++ b/structured/hint_types/condition.py
@@ -40,7 +40,10 @@ class Condition(Generic[S, Unpack[Ts]]):
     def _transform(base_type: Any, hint: Any) -> Any:
         if isinstance(hint, Condition):
             if not isinstance(base_type, Serializer):
-                raise TypeError('Condition must be paired with a serialized type.')
+                raise TypeError(
+                    'Condition must be paired with a serialized type, got '
+                    f'{base_type}'
+                )
             return ConditionalSerializer(base_type, hint.condition, hint.defaults)
 
 

--- a/structured/hint_types/strings.py
+++ b/structured/hint_types/strings.py
@@ -12,11 +12,13 @@ __all__ = [
     'NET',
 ]
 
+import math
 from functools import cache, partial
 
 from ..base_types import requires_indexing
 from ..serializers import (
     DynamicCharSerializer,
+    ConsumingCharSerializer,
     NETCharSerializer,
     Serializer,
     TCharSerializer,
@@ -72,6 +74,8 @@ class char(bytes, requires_indexing):
             return StructuredAlias(cls, (count,))  # type: ignore
         elif isinstance(count, bytes):
             serializer = TerminatedCharSerializer(count)
+        elif math.isinf(count) and count > 0:
+            serializer = ConsumingCharSerializer()
         else:
             raise TypeError(
                 f'{cls.__qualname__}[] count must be an int, NET, terminator '

--- a/structured/hint_types/strings.py
+++ b/structured/hint_types/strings.py
@@ -17,8 +17,8 @@ from functools import cache, partial
 
 from ..base_types import requires_indexing
 from ..serializers import (
-    DynamicCharSerializer,
     ConsumingCharSerializer,
+    DynamicCharSerializer,
     NETCharSerializer,
     Serializer,
     TCharSerializer,

--- a/structured/serializers/api.py
+++ b/structured/serializers/api.py
@@ -40,6 +40,7 @@ from ..type_checking import (
     ClassVar,
     Generic,
     Iterable,
+    Optional,
     ReadableBuffer,
     Self,
     Ss,
@@ -163,7 +164,7 @@ class Serializer(Generic[Unpack[Ts]]):
         """
         return self.get_final() is not None
 
-    def get_final(self) -> Serializer | None:
+    def get_final(self) -> Optional[Serializer]:
         """Get the serializer (if any) that makes this serializer the final
         serializer.
         """
@@ -248,7 +249,7 @@ class CompoundSerializer(Generic[Unpack[Ts]], Serializer[Unpack[Ts]]):
             for serializer in serializers
         )
 
-    def get_final(self) -> Serializer | None:
+    def get_final(self) -> Optional[Serializer]:
         return self.serializers[-1].get_final()
 
     def prepack(self, partial_object: Any) -> Serializer:

--- a/structured/serializers/api.py
+++ b/structured/serializers/api.py
@@ -40,6 +40,7 @@ from ..type_checking import (
     ClassVar,
     Generic,
     Iterable,
+    NoReturn,
     ReadableBuffer,
     Self,
     Ss,
@@ -156,13 +157,30 @@ class Serializer(Generic[Unpack[Ts]]):
         :return: A new serializer, or this one if no changes were needed.
         """
         return self
+    
+    def is_final(self) -> bool:
+        """Indicates if this serializer must be the final serializer in a
+        chain.
+        """
+        return self.get_final() is not None
+    
+    def get_final(self) -> Serializer | None:
+        """Get the serializer (if any) that makes this serializer the final
+        serializer.
+        """
+        return None
 
     def __add__(
         self, other: Serializer[Unpack[Ss]]
     ) -> CompoundSerializer[Unpack[Ts], Unpack[Ss]]:
-        if isinstance(other, (CompoundSerializer, NullSerializer)):
-            # Allow the other __radd__ to work, even in cases where other is
-            # not a subclass of self (ie: StructSerializer + CompoundSerializer)
+        if isinstance(other, NullSerializer):
+            # Allow __radd__ to work
+            return NotImplemented
+        elif self.is_final():
+            final = self.get_final()
+            raise TypeError(f'{type(self).__name__} must be the final serializer (is or contains {final}), but is followed by {other}')
+        if isinstance(other, CompoundSerializer):
+            # Allow __radd__ to work
             return NotImplemented
         elif isinstance(other, Serializer):
             # Default is to make a CompoundSerializer joining the two.
@@ -207,7 +225,7 @@ class NullSerializer(Serializer[Unpack[tuple[()]]]):
 
     def __radd__(self, other: TSerializer) -> TSerializer:
         return self.__add__(other)
-
+    
 
 class CompoundSerializer(Generic[Unpack[Ts]], Serializer[Unpack[Ts]]):
     """A serializer that chains together multiple serializers."""
@@ -227,6 +245,11 @@ class CompoundSerializer(Generic[Unpack[Ts]], Serializer[Unpack[Ts]]):
             != (Serializer.prepack, Serializer.preunpack)
             for serializer in serializers
         )
+
+    def get_final(self) -> Serializer | None:
+        for serializer in self.serializers:
+            if serializer.is_final():
+                return serializer
 
     def prepack(self, partial_object: Any) -> Serializer:
         return self.preprocess(partial_object)

--- a/structured/serializers/conditional.py
+++ b/structured/serializers/conditional.py
@@ -3,6 +3,7 @@ Serializer that wraps another in a condition. When the condition evaluates
 to a Truthy value, the original serializer operates as normal. Otherwise,
 it acts as if the serializer was not there.
 """
+
 from __future__ import annotations
 
 __all__ = [

--- a/structured/serializers/conditional.py
+++ b/structured/serializers/conditional.py
@@ -3,6 +3,7 @@ Serializer that wraps another in a condition. When the condition evaluates
 to a Truthy value, the original serializer operates as normal. Otherwise,
 it acts as if the serializer was not there.
 """
+from __future__ import annotations
 
 __all__ = [
     'ConditionalSerializer',
@@ -14,6 +15,7 @@ from ..type_checking import (
     BinaryIO,
     Callable,
     Generic,
+    Optional,
     ReadableBuffer,
     Self,
     Ts,
@@ -52,7 +54,7 @@ class ConditionalSerializer(Generic[Unpack[Ts]], Serializer[Unpack[Ts]]):
                 f'{self.num_values}, got {expected}'
             )
 
-    def get_final(self) -> Serializer | None:
+    def get_final(self) -> Optional[Serializer]:
         return self.serializers[True].get_final()
 
     def with_byte_order(self, byte_order: ByteOrder) -> Self:

--- a/structured/serializers/conditional.py
+++ b/structured/serializers/conditional.py
@@ -51,6 +51,9 @@ class ConditionalSerializer(Generic[Unpack[Ts]], Serializer[Unpack[Ts]]):
                 'Not enough default arguments provided to Condition, expected '
                 f'{self.num_values}, got {expected}'
             )
+        
+    def get_final(self) -> Serializer | None:
+        return self.serializers[True].get_final()
 
     def with_byte_order(self, byte_order: ByteOrder) -> Self:
         serializer = self.serializers[True].with_byte_order(byte_order)

--- a/structured/serializers/conditional.py
+++ b/structured/serializers/conditional.py
@@ -51,7 +51,7 @@ class ConditionalSerializer(Generic[Unpack[Ts]], Serializer[Unpack[Ts]]):
                 'Not enough default arguments provided to Condition, expected '
                 f'{self.num_values}, got {expected}'
             )
-        
+
     def get_final(self) -> Serializer | None:
         return self.serializers[True].get_final()
 

--- a/structured/serializers/strings.py
+++ b/structured/serializers/strings.py
@@ -22,6 +22,7 @@ from ..type_checking import (
     BinaryIO,
     Callable,
     ClassVar,
+    Optional,
     ReadableBuffer,
     Self,
     Union,
@@ -368,7 +369,7 @@ class UnicodeSerializer(Serializer[str]):
         self.encoder = encoder
         self.decoder = decoder
 
-    def get_final(self) -> Serializer | None:
+    def get_final(self) -> Optional[Serializer]:
         return self.serializer.get_final()
 
     @property

--- a/structured/serializers/strings.py
+++ b/structured/serializers/strings.py
@@ -22,7 +22,6 @@ from ..type_checking import (
     BinaryIO,
     Callable,
     ClassVar,
-    Literal,
     ReadableBuffer,
     Self,
     Union,
@@ -138,10 +137,11 @@ class DynamicCharSerializer(Serializer[bytes]):
         self.size = self.st.size + count
         st = _single_char @ count
         return st.unpack_read(readable)
-    
+
 
 class ConsumingCharSerializer(Serializer[bytes]):
     """Serializer for using all remainging bytes for the character data."""
+
     num_values: ClassVar[int] = 1
 
     def __init__(self) -> None:
@@ -153,11 +153,13 @@ class ConsumingCharSerializer(Serializer[bytes]):
     def pack(self, *values: Unpack[tuple[bytes]]) -> bytes:
         self.size = len(values[0])
         return values[0]
-    
-    def pack_into(self, buffer: WritableBuffer, offset: int, *values: Unpack[tuple[bytes]]) -> None:
+
+    def pack_into(
+        self, buffer: WritableBuffer, offset: int, *values: Unpack[tuple[bytes]]
+    ) -> None:
         data = values[0]
         self.size = len(data)
-        buffer[offset:offset + self.size] = data
+        buffer[offset : offset + self.size] = data
 
     def pack_write(self, writable: BinaryIO, *values: Unpack[tuple[bytes]]) -> None:
         data = values[0]
@@ -166,17 +168,17 @@ class ConsumingCharSerializer(Serializer[bytes]):
 
     def unpack(self, buffer: ReadableBuffer) -> tuple[bytes]:
         self.size = len(buffer)
-        return buffer,
-    
+        return (buffer,)
+
     def unpack_from(self, buffer: ReadableBuffer, offset: int = 0) -> tuple[bytes]:
         self.size = len(buffer) - offset
-        return buffer[offset:],
-    
+        return (buffer[offset:],)
+
     def unpack_read(self, readable: BinaryIO) -> tuple[bytes]:
         data = readable.read()
         self.size = len(data)
-        return data,
-        
+        return (data,)
+
 
 class TerminatedCharSerializer(Serializer[bytes]):
     """Serializer for handling terminated strings (typically null-terminated)."""

--- a/structured/serializers/strings.py
+++ b/structured/serializers/strings.py
@@ -10,6 +10,7 @@ import struct
 __all__ = [
     'TerminatedCharSerializer',
     'DynamicCharSerializer',
+    'ConsumingCharSerializer',
     'NETCharSerializer',
     'static_char_serializer',
     'UnicodeSerializer',
@@ -21,6 +22,7 @@ from ..type_checking import (
     BinaryIO,
     Callable,
     ClassVar,
+    Literal,
     ReadableBuffer,
     Self,
     Union,
@@ -136,7 +138,45 @@ class DynamicCharSerializer(Serializer[bytes]):
         self.size = self.st.size + count
         st = _single_char @ count
         return st.unpack_read(readable)
+    
 
+class ConsumingCharSerializer(Serializer[bytes]):
+    """Serializer for using all remainging bytes for the character data."""
+    num_values: ClassVar[int] = 1
+
+    def __init__(self) -> None:
+        self.size = 0
+
+    def get_final(self) -> Self:
+        return self
+
+    def pack(self, *values: Unpack[tuple[bytes]]) -> bytes:
+        self.size = len(values[0])
+        return values[0]
+    
+    def pack_into(self, buffer: WritableBuffer, offset: int, *values: Unpack[tuple[bytes]]) -> None:
+        data = values[0]
+        self.size = len(data)
+        buffer[offset:offset + self.size] = data
+
+    def pack_write(self, writable: BinaryIO, *values: Unpack[tuple[bytes]]) -> None:
+        data = values[0]
+        self.size = len(data)
+        writable.write(data)
+
+    def unpack(self, buffer: ReadableBuffer) -> tuple[bytes]:
+        self.size = len(buffer)
+        return buffer,
+    
+    def unpack_from(self, buffer: ReadableBuffer, offset: int = 0) -> tuple[bytes]:
+        self.size = len(buffer) - offset
+        return buffer[offset:],
+    
+    def unpack_read(self, readable: BinaryIO) -> tuple[bytes]:
+        data = readable.read()
+        self.size = len(data)
+        return data,
+        
 
 class TerminatedCharSerializer(Serializer[bytes]):
     """Serializer for handling terminated strings (typically null-terminated)."""
@@ -312,6 +352,7 @@ TCharSerializer = Union[
     DynamicCharSerializer,
     NETCharSerializer,
     TerminatedCharSerializer,
+    ConsumingCharSerializer,
 ]
 
 
@@ -324,6 +365,9 @@ class UnicodeSerializer(Serializer[str]):
         self.serializer = char_serializer
         self.encoder = encoder
         self.decoder = decoder
+
+    def get_final(self) -> Serializer | None:
+        return self.serializer.get_final()
 
     @property
     def size(self) -> int:

--- a/structured/serializers/structured.py
+++ b/structured/serializers/structured.py
@@ -12,6 +12,7 @@ from ..type_checking import (
     BinaryIO,
     ClassVar,
     Generic,
+    Optional,
     ReadableBuffer,
     TypeVar,
     WritableBuffer,
@@ -44,7 +45,7 @@ class StructuredSerializer(Generic[TStructured], Serializer[TStructured]):
         self.obj_type = obj_type
         self.size = 0
 
-    def get_final(self) -> Serializer | None:
+    def get_final(self) -> Optional[Serializer]:
         return self.obj_type.serializer.get_final()
 
     def pack(self, values: TStructured) -> bytes:

--- a/structured/serializers/structured.py
+++ b/structured/serializers/structured.py
@@ -44,6 +44,9 @@ class StructuredSerializer(Generic[TStructured], Serializer[TStructured]):
         self.obj_type = obj_type
         self.size = 0
 
+    def get_final(self) -> Serializer | None:
+        return self.obj_type.serializer.get_final()
+
     def pack(self, values: TStructured) -> bytes:
         data = values.pack()
         self.size = values.serializer.size

--- a/structured/serializers/tuples.py
+++ b/structured/serializers/tuples.py
@@ -28,6 +28,9 @@ class TupleSerializer(Generic[Unpack[Ts]], Serializer[Unpack[Ts]]):
     def __init__(self, serializers: Iterable[Serializer]) -> None:
         self.serializer = sum(serializers, NullSerializer())
 
+    def get_final(self) -> Serializer | None:
+        return self.serializer.get_final()
+
     @property
     def size(self) -> int:
         return self.serializer.size

--- a/structured/serializers/tuples.py
+++ b/structured/serializers/tuples.py
@@ -14,6 +14,7 @@ from ..type_checking import (
     ClassVar,
     Generic,
     Iterable,
+    Optional,
     ReadableBuffer,
     Ts,
     Unpack,
@@ -28,7 +29,7 @@ class TupleSerializer(Generic[Unpack[Ts]], Serializer[Unpack[Ts]]):
     def __init__(self, serializers: Iterable[Serializer]) -> None:
         self.serializer = sum(serializers, NullSerializer())
 
-    def get_final(self) -> Serializer | None:
+    def get_final(self) -> Optional[Serializer]:
         return self.serializer.get_final()
 
     @property

--- a/structured/serializers/unions.py
+++ b/structured/serializers/unions.py
@@ -52,6 +52,11 @@ class AUnion(Serializer):
         }
         self.size = 0
 
+    def get_final(self) -> Serializer | None:
+        for serializer in self.result_map.values():
+            if serializer.is_final():
+                return serializer.get_final()
+
     @staticmethod
     def validate_serializer(hint) -> Serializer:
         serializer = annotated.transform(hint)

--- a/structured/serializers/unions.py
+++ b/structured/serializers/unions.py
@@ -19,6 +19,7 @@ from ..type_checking import (
     Callable,
     ClassVar,
     Iterable,
+    Optional,
     ReadableBuffer,
     WritableBuffer,
     annotated,
@@ -35,8 +36,8 @@ class AUnion(Serializer):
 
     num_values: ClassVar[int] = 1
     result_map: dict[Any, Serializer]
-    default: Serializer | None
-    _last_serializer: Serializer | None
+    default: Optional[Serializer]
+    _last_serializer: Optional[Serializer]
 
     def __init__(self, result_map: dict[Any, Any], default: Any = None) -> None:
         """result_map should be a mapping of possible return values from `decider`
@@ -52,7 +53,7 @@ class AUnion(Serializer):
         }
         self.size = 0
 
-    def get_final(self) -> Serializer | None:
+    def get_final(self) -> Optional[Serializer]:
         for serializer in self.result_map.values():
             if serializer.is_final():
                 return serializer.get_final()

--- a/structured/structured.py
+++ b/structured/structured.py
@@ -53,7 +53,7 @@ def ispad(annotation: Any) -> bool:
     )
 
 
-def final_transform(base_type: Any, hint: Any) -> Serializer | None:
+def final_transform(base_type: Any, hint: Any) -> Optional[Serializer]:
     if isinstance(hint, Serializer):
         return hint
 
@@ -120,8 +120,8 @@ def get_structured_base(cls: type[Structured]) -> Optional[type[Structured]]:
 def gen_init(
     args: dict[str, Any],
     *,
-    globalsns: dict[str, Any] | None = None,
-    localsns: dict[str, Any] | None = None,
+    globalsns: Optional[dict[str, Any]] = None,
+    localsns: Optional[dict[str, Any]] = None,
 ) -> Callable:
     """Generates an __init__ method for a class.  `args` should be a mapping of
     arguments to type annotations to be used in the method definition.

--- a/structured/type_checking.py
+++ b/structured/type_checking.py
@@ -21,6 +21,7 @@ from typing import (
     Generic,
     Iterable,
     Iterator,
+    Literal,
     NewType,
     NoReturn,
     Optional,

--- a/structured/type_checking.py
+++ b/structured/type_checking.py
@@ -115,7 +115,9 @@ def istuple(annotation: Any) -> TypeGuard[tuple]:
     return get_origin(annotation) in (tuple, Tuple)
 
 
-def get_tuple_args(annotation: Any, fixed_size: bool = True) -> Optional[tuple[Any, ...]]:
+def get_tuple_args(
+    annotation: Any, fixed_size: bool = True
+) -> Optional[tuple[Any, ...]]:
     """Get the arguments to a tuple type hint, or None if the annotation is not
     a tuple hint.  If `fixed_size` is True (default), then the tuple must be
     a fixed length tuple hint.

--- a/structured/type_checking.py
+++ b/structured/type_checking.py
@@ -115,7 +115,7 @@ def istuple(annotation: Any) -> TypeGuard[tuple]:
     return get_origin(annotation) in (tuple, Tuple)
 
 
-def get_tuple_args(annotation: Any, fixed_size: bool = True) -> tuple[Any, ...] | None:
+def get_tuple_args(annotation: Any, fixed_size: bool = True) -> Optional[tuple[Any, ...]]:
     """Get the arguments to a tuple type hint, or None if the annotation is not
     a tuple hint.  If `fixed_size` is True (default), then the tuple must be
     a fixed length tuple hint.

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,14 @@
 import io
 
-from structured import Structured
+from structured import Structured, Serializer
+
+
+class Final(Serializer):
+    num_values = 1
+    size = 0
+
+    def get_final(self):
+        return self
 
 
 def standard_tests(target_obj: Structured, target_data: bytes):

--- a/tests/test_arrays.py
+++ b/tests/test_arrays.py
@@ -6,7 +6,7 @@ import pytest
 
 from structured import *
 
-from . import standard_tests
+from . import standard_tests, Final
 
 
 class Item(Structured):
@@ -212,3 +212,8 @@ def test_dynamic_checked_structured(items: list[Item]):
     struct.pack_into('3I', buffer, 0, 42, 3, 0) # write over data_size with 0
     with pytest.raises(ValueError):
         Compound.create_unpack_from(buffer)
+
+
+def test_finality() -> None:
+    with pytest.raises(TypeError):
+        array[Header[3], Final()]

--- a/tests/test_conditional.py
+++ b/tests/test_conditional.py
@@ -5,7 +5,7 @@ import pytest
 from structured import *
 from structured.type_checking import Annotated
 
-from . import standard_tests
+from . import standard_tests, Final
 
 
 class TestConditional:
@@ -51,3 +51,11 @@ class TestConditional:
         assert v3_obj.pack() == v2_data
         v3_obj.version = 1
         assert v3_obj.pack() == v1_data
+
+    def test_finality(self) -> None:
+        class Base(Structured):
+            a: Annotated[int, Final(), Condition(lambda x: True, 0)]
+
+        assert isinstance(Base.serializer, ConditionalSerializer)
+        assert Base.serializer.serializers[True].is_final()
+        assert Base.serializer.is_final()

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -153,6 +153,6 @@ class TestUnionSerializer:
     def test_finality(self) -> None:
         class Base(Structured):
             # Note: the actual serializer(s) used for unpacking occur in the LookbackDecider
-            a: Annotated[uint32|float32, LookbackDecider(lambda x: 0, {0:uint32, 1:Final()})]
+            a: Annotated[Union[uint32|float32], LookbackDecider(lambda x: 0, {0:uint32, 1:Final()})]
 
         assert Base.serializer.is_final()

--- a/tests/test_serializers.py
+++ b/tests/test_serializers.py
@@ -153,6 +153,6 @@ class TestUnionSerializer:
     def test_finality(self) -> None:
         class Base(Structured):
             # Note: the actual serializer(s) used for unpacking occur in the LookbackDecider
-            a: Annotated[Union[uint32|float32], LookbackDecider(lambda x: 0, {0:uint32, 1:Final()})]
+            a: Annotated[Union[uint32,float32], LookbackDecider(lambda x: 0, {0:uint32, 1:Final()})]
 
         assert Base.serializer.is_final()

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -1,5 +1,6 @@
 import io
 import struct
+import math
 
 import pytest
 
@@ -22,7 +23,6 @@ def test_errors() -> None:
         char[1.1]
     with pytest.raises(ValueError):
         char[b'aa']
-
 
 
 class TestChar:
@@ -119,7 +119,6 @@ class TestChar:
         #with pytest.raises(ValueError):
         #    Base.create_unpack(error_data)
 
-
     def test_net(self) -> None:
         # NOTE: Code for encoding/decoding the string length is dubious.
         # Source is old Wrye Base code for reading/writing OMODs, but I've
@@ -165,6 +164,10 @@ class TestChar:
             assert stream.getvalue()[:partial_size] == partial_target
             stream.seek(0)
             assert Base.create_unpack_read(stream) == target_obj
+
+    def test_finality(self) -> None:
+        assert isinstance(s := annotated.transform(char[math.inf]), Serializer)
+        assert s.is_final()
 
 
 class TestUnicode:
@@ -275,3 +278,7 @@ class TestUnicode:
         with pytest.raises(ValueError):
             with io.BytesIO(error_data) as ins:
                 Base.create_unpack_read(ins)
+
+    def test_finality(self) -> None:
+        assert isinstance(s := annotated.transform(unicode[math.inf]), Serializer)
+        assert s.is_final()

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -169,6 +169,19 @@ class TestChar:
         assert isinstance(s := annotated.transform(char[math.inf]), Serializer)
         assert s.is_final()
 
+    def test_consuming(self) -> None:
+        class Base(Structured):
+            a: uint8
+            b: char[math.inf]
+
+        target_data1 = struct.pack('B', 42) + b'Hello'
+        target_obj = Base(42, b'Hello')
+        standard_tests(target_obj, target_data1)
+
+        target_data2 = struct.pack('B', 42) + b''
+        target_obj.b = b''
+        standard_tests(target_obj, target_data2)
+
 
 class TestUnicode:
     def test_default(self) -> None:

--- a/tests/test_tuples.py
+++ b/tests/test_tuples.py
@@ -3,7 +3,7 @@ from typing import Tuple, Generic, TypeVar
 
 from structured import *
 
-from . import standard_tests
+from . import standard_tests, Final
 
 
 T = TypeVar('T')
@@ -51,3 +51,10 @@ def test_generics():
     class ConcreteStruct2(GenericStruct[int8, int16]):
         pass
     assert isinstance(ConcreteStruct2.serializer, TupleSerializer)
+
+
+def test_finality():
+    final = Final()
+    class Base(Structured):
+        a: tuple[int8, final]
+    assert Base.serializer.is_final()


### PR DESCRIPTION
Implements the ability to hint with `char[math.inf]` and `unicode[math.inf]`.

Closes #45